### PR TITLE
fix: disable mouse on icon when exiting edit mode

### DIFF
--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -9102,6 +9102,17 @@ function DoiteConditions_Show(key)
     condFrame:SetFrameStrata("FULLSCREEN_DIALOG")
     -- When the conditions editor hides by any means, drop the edit override
     condFrame:SetScript("OnHide", function()
+      -- Disable mouse on the icon that was being edited (fixes drag after exit bug)
+      local _GetIconFrame = DoiteAuras_GetIconFrame or function(k)
+        return k and _G["DoiteIcon_" .. k]
+      end
+      if currentKey then
+        local oldFrame = _GetIconFrame(currentKey)
+        if oldFrame then
+          oldFrame:EnableMouse(false)
+        end
+      end
+
       _G["DoiteEdit_CurrentKey"] = nil
       lastAnnouncedKey = nil
 


### PR DESCRIPTION
Previously, when the edit panel was closed by any means other than explicitly toggling the same icon, the icon would remain draggable until UI reload. This was because the OnHide handler cleared the edit key but didn't disable mouse input on the icon frame.

Now the OnHide handler properly calls EnableMouse(false) on the previously-edited icon before clearing the currentKey.