### PR TITLE
fix: block item use while in edit mode (closes #50)

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -2545,6 +2545,8 @@ local function RefreshIcons()
         if isClickable then
              f:EnableMouse(true)
              f:SetScript("OnClick", function()
+                 -- Block item use while in edit mode (Issue #50)
+                 if _G["DoiteEdit_CurrentKey"] then return end
                  if arg1 == "LeftButton" or arg1 == "RightButton" then
                     -- Fallback to 'key' if name is missing (fixes nil error)
                     local n = (data.displayName or data.name) or key


### PR DESCRIPTION
Added edit mode guard inside OnClick handler. Previously, the check only ran when attaching the handler in RefreshIcons, so clicks still fired if edit mode was toggled after the handler was already set.