### PR TITLE
Add DoiteTargetAuras and migrate aura evaluation to target-focused checks

### DIFF
--- a/DoiteAuras.toc
+++ b/DoiteAuras.toc
@@ -9,6 +9,7 @@ DoiteAuras.lua
 
 Modules\DoiteBuffData.lua
 Modules\DoitePlayerAuras.lua
+Modules\DoiteTargetAuras.lua
 Modules\DoiteEdit.lua
 Modules\DoiteGlow.lua
 Modules\DoiteConditions.lua

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2342,21 +2342,12 @@ local function _GetBaseXY(key, dataTbl)
 end
 
 -- Player-only aura remaining (seconds); nil if not timed / not found.
-local function _PlayerAuraRemainingSeconds(auraName)
+local function _TargetAuraRemainingSeconds(auraName)
   if not auraName then
     return nil
   end
 
-  local playerAuraSlot = DoitePlayerAuras.GetActiveAuraSlot(auraName)
-  if playerAuraSlot then
-    local _, remainingMs, _ = GetPlayerAuraDuration(playerAuraSlot)
-    if remainingMs and remainingMs > 0 then
-      return remainingMs / 1000
-    end
-  end
-
-  -- get remaining for buff cap spells
-  local remaining = DoitePlayerAuras.GetHiddenBuffRemaining(auraName)
+  local remaining = DoiteTargetAuras.GetHiddenBuffRemaining(auraName)
   if remaining and remaining > 0 then
     return remaining
   end
@@ -2440,55 +2431,21 @@ local function _DoiteTrackRemainingPass(spellName, unit, comp, threshold)
   return nil
 end
 
--- For debuff checks only: if all debuff slots are full and the name exists in buffs, treat it as a debuff hit
+-- Target aura checks use DoiteTargetAuras (includes buff-cap overflow handling).
 local function _TargetHasOverflowDebuff(auraName)
-  if not auraName then
-    return false
-  end
-
-  local snap = auraSnapshot["target"]
-  if not snap then
-    return false
-  end
-
-  local debuffs = snap.debuffs
-  if debuffs and debuffs[auraName] == true then
-    return true
-  end
-
-  local count = snap.debuffCount or 0
-  if count < 16 then
-    -- Debuff bar not "full", so don't risk treating a real buff as debuff.
-    return false
-  end
-
-  local buffs = snap.buffs
-  if buffs and buffs[auraName] == true then
-    return true
-  end
-
-  return false
+  return DoiteTargetAuras.HasDebuff(auraName)
 end
 
 local function _TargetHasAura(auraName, wantDebuff)
-  local unit = "target"
-
-  if not unit or not auraName or not UnitExists(unit) then
-    return false
-  end
-
-  local snap = auraSnapshot[unit]
-  if not snap then
+  if not auraName or not UnitExists("target") then
     return false
   end
 
   if wantDebuff then
-    -- Debuff checks: first real debuffs, then overflow in buffs.
-    return _TargetHasOverflowDebuff(auraName)
-  else
-    local b = snap.buffs
-    return b and b[auraName] == true
+    return DoiteTargetAuras.HasDebuff(auraName)
   end
+
+  return DoiteTargetAuras.HasBuff(auraName)
 end
 
 -- Talent helpers for auraConditions (Known / Not known)
@@ -2638,14 +2595,18 @@ local function _AuraConditions_CheckEntry(entry)
   ----------------------------------------------------------------
   local wantDebuff = (entry.buffType == "DEBUFF")
 
-  local unit = entry.unit or "player"
+  local unit = entry.unit or "target"
   if unit ~= "player" and unit ~= "target" then
-    unit = "player"
+    unit = "target"
   end
 
-  -- If explicitly target "target" but have no target, do not pass
-  if unit == "target" and (not UnitExists("target")) then
+  if not UnitExists("target") then
     return false
+  end
+
+  -- shift legacy player aura unit checks onto target auras
+  if unit == "player" then
+    unit = "target"
   end
 
   ----------------------------------------------------------------
@@ -2689,16 +2650,7 @@ local function _AuraConditions_CheckEntry(entry)
   ----------------------------------------------------------------
   local hasAura = false
 
-  if unit == "player" then
-    if (not wantDebuff) and DoitePlayerAuras.HasBuff(name) then
-      hasAura = true
-    elseif wantDebuff and DoitePlayerAuras.HasDebuff(name) then
-      hasAura = true
-    end
-  else
-    -- unit == "target"
-    hasAura = _TargetHasAura(name, wantDebuff)
-  end
+  hasAura = _TargetHasAura(name, wantDebuff)
 
   ----------------------------------------------------------------
   -- If stacks enabled and aura exists, compute stacks and compare.
@@ -2779,22 +2731,21 @@ _StacksPasses = function(cnt, comp, target)
   return true
 end
 
--- Get stack count for a named aura on target (or player). Uses DoitePlayerAuras for player checks.
+-- Get stack count for a named aura on a unit. Uses DoiteTargetAuras for target checks.
 _GetAuraStacksOnUnit = function(unit, auraName, wantDebuff)
   if not unit or not auraName then
     return nil
   end
 
-  -- Use DoitePlayerAuras for player checks
-  if unit == "player" then
+  if unit == "target" then
     if wantDebuff then
-      return DoitePlayerAuras.GetDebuffStacks(auraName)
+      return DoiteTargetAuras.GetDebuffStacks(auraName)
     else
-      return DoitePlayerAuras.GetBuffStacks(auraName)
+      return DoiteTargetAuras.GetBuffStacks(auraName)
     end
   end
 
-  -- TODO improve logic for other units
+  -- fallback logic for units other than current target
   ----------------------------------------------------------------
   -- Primary scan: normal BUFF / DEBUFF list for non-player units
   ----------------------------------------------------------------
@@ -4365,10 +4316,10 @@ function DoiteConditions:_ClearTargetAuraSnapshot()
   end
 end
 
--- _RebuildPlayerAuraTimers removed - now using DoitePlayerAuras for on-demand time calculation
+-- _RebuildTargetAuraTimers removed - now using DoiteTargetAuras for on-demand time calculation
 
 function DoiteConditions:ProcessPendingAuraScans()
-  -- Player aura scanning removed - now handled by DoitePlayerAuras event-driven tracking
+  -- Target aura scanning removed - now handled by DoiteTargetAuras event-driven tracking
 
   -- Target: scan if (and only if) target aura tracking is in use; else keep snapshot empty.
   if self._pendingAuraScanTarget then
@@ -5474,16 +5425,16 @@ local function CheckAuraConditions(data)
 
   local found = false
 
-  -- Self auras — aura on player, regardless of target
+  -- Self auras now evaluate against current target auras
   if (not found) and allowSelf then
     local hit = false
 
     if wantBuff then
-      hit = DoitePlayerAuras.HasBuff(name)
+      hit = DoiteTargetAuras.HasBuff(name)
     end
 
     if (not hit) and wantDebuff then
-      hit = DoitePlayerAuras.HasDebuff(name)
+      hit = DoiteTargetAuras.HasDebuff(name)
     end
 
     if hit then
@@ -5536,7 +5487,7 @@ local function CheckAuraConditions(data)
     local ownerUnit = nil
 
     if allowSelf then
-      ownerUnit = "player"
+      ownerUnit = "target"
     elseif (allowHelp or allowHarm) and UnitExists("target") then
       ownerUnit = "target"
     end
@@ -5715,7 +5666,7 @@ local function CheckAuraConditions(data)
 
         if targetSelf then
           -- PLAYER/SELF remaining time must reflect the actual visible aura time (vanilla API)
-          local rem = _PlayerAuraRemainingSeconds(name)
+          local rem = _TargetAuraRemainingSeconds(name)
 
           if rem and rem > 0 then
             pass = _RemainingPasses(rem, comp, threshold)
@@ -6121,7 +6072,7 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
 
         if targetSelf then
           -- PLAYER/SELF remaining-time text must reflect the actual visible aura time (vanilla/tooltip scan), never DoiteTrack. Ownership filtering (onlyMine/onlyOthers) belongs in the condition logic.
-          remAura = _PlayerAuraRemainingSeconds(auraName)
+          remAura = _TargetAuraRemainingSeconds(auraName)
         else
           -- Target remaining time relies on DoiteTrack (vanilla target auras don't expose durations).
           remAura = _DoiteTrackAuraRemainingSeconds(auraName, "target")

--- a/Modules/DoiteTargetAuras.lua
+++ b/Modules/DoiteTargetAuras.lua
@@ -1,0 +1,415 @@
+---------------------------------------------------------------
+-- DoiteTargetAuras.lua
+-- Target aura cache + lookup helpers (buffs/debuffs, slot + stack counts)
+-- Please respect license note: Ask permission
+-- WoW 1.12 | Lua 5.0
+---------------------------------------------------------------
+local MAX_BUFF_SLOTS = 32
+local MAX_DEBUFF_SLOTS = 16
+
+local DoiteTargetAuras = {
+  buffs = {}, -- slot -> { spellId, stacks }
+  debuffs = {}, -- slot -> { spellId, stacks }
+
+  spellIdToNameCache = {}, -- spellId -> spell name
+  spellNameToIdCache = {}, -- spell name -> spellId
+  spellNameToMaxStacks = {}, -- spell name -> max stacks
+
+  activeBuffs = {}, -- spell name -> slot
+  activeDebuffs = {}, -- spell name -> slot
+
+  cappedBuffsExpirationTime = {}, -- spell name -> expiration time in seconds
+  cappedBuffsStacks = {}, -- spell name -> stacks
+
+  targetGuid = "",
+
+  buffCapEventsEnabled = false,
+}
+
+for i = 1, MAX_BUFF_SLOTS do
+  table.insert(DoiteTargetAuras.buffs, { spellId = nil, stacks = nil })
+end
+for i = 1, MAX_DEBUFF_SLOTS do
+  table.insert(DoiteTargetAuras.debuffs, { spellId = nil, stacks = nil })
+end
+
+_G["DoiteTargetAuras"] = DoiteTargetAuras
+
+local function MarkActive(spellId, activeTable, slot)
+  if not DoiteTargetAuras.spellIdToNameCache[spellId] then
+    local spellName = GetSpellRecField(spellId, "name")
+    if spellName then
+      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
+      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
+      activeTable[spellName] = slot
+    end
+  else
+    local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
+    if spellName then
+      activeTable[spellName] = slot
+    end
+  end
+end
+
+local function MarkInactive(spellId, activeTable)
+  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
+  if spellName then
+    activeTable[spellName] = false
+  end
+end
+
+local function RemoveCappedBuff(spellName)
+  DoiteTargetAuras.cappedBuffsExpirationTime[spellName] = 0
+  DoiteTargetAuras.cappedBuffsStacks[spellName] = 0
+end
+
+local function ResetAuras()
+  local i
+  for i = 1, MAX_BUFF_SLOTS do
+    DoiteTargetAuras.buffs[i].spellId = nil
+    DoiteTargetAuras.buffs[i].stacks = nil
+  end
+  for i = 1, MAX_DEBUFF_SLOTS do
+    DoiteTargetAuras.debuffs[i].spellId = nil
+    DoiteTargetAuras.debuffs[i].stacks = nil
+  end
+  DoiteTargetAuras.activeBuffs = {}
+  DoiteTargetAuras.activeDebuffs = {}
+end
+
+local function UpdateTargetGuid()
+  local _, guid = UnitExists("target")
+  if guid and guid ~= "" then
+    DoiteTargetAuras.targetGuid = guid
+    return true
+  end
+  DoiteTargetAuras.targetGuid = ""
+  return false
+end
+
+local function UpdateAuras()
+  if not UpdateTargetGuid() then
+    ResetAuras()
+    return
+  end
+
+  local auraSpellIds = GetUnitField("target", "aura")
+  local auraStacks = GetUnitField("target", "auraApplications")
+
+  if not auraSpellIds or not auraStacks then
+    ResetAuras()
+    return
+  end
+
+  DoiteTargetAuras.activeBuffs = {}
+  DoiteTargetAuras.activeDebuffs = {}
+
+  local i
+  for i = 1, MAX_BUFF_SLOTS do
+    local spellId = auraSpellIds[i]
+    if spellId and spellId ~= 0 then
+      DoiteTargetAuras.buffs[i].spellId = spellId
+      DoiteTargetAuras.buffs[i].stacks = auraStacks[i] + 1
+      MarkActive(spellId, DoiteTargetAuras.activeBuffs, i)
+    else
+      DoiteTargetAuras.buffs[i].spellId = nil
+      DoiteTargetAuras.buffs[i].stacks = nil
+    end
+  end
+
+  for i = 1, MAX_DEBUFF_SLOTS do
+    local auraIndex = MAX_BUFF_SLOTS + i
+    local spellId = auraSpellIds[auraIndex]
+    if spellId and spellId ~= 0 then
+      DoiteTargetAuras.debuffs[i].spellId = spellId
+      DoiteTargetAuras.debuffs[i].stacks = auraStacks[auraIndex] + 1
+      MarkActive(spellId, DoiteTargetAuras.activeDebuffs, i)
+    else
+      DoiteTargetAuras.debuffs[i].spellId = nil
+      DoiteTargetAuras.debuffs[i].stacks = nil
+    end
+  end
+end
+
+function DoiteTargetAuras.Refresh()
+  UpdateAuras()
+end
+
+function DoiteTargetAuras.IsHiddenByBuffCap(spellName)
+  local expirationTime = DoiteTargetAuras.cappedBuffsExpirationTime[spellName]
+  if expirationTime and expirationTime > 0 then
+    if expirationTime > GetTime() then
+      return true
+    end
+    RemoveCappedBuff(spellName)
+  end
+  return false
+end
+
+function DoiteTargetAuras.IsActive(spellName)
+  return DoiteTargetAuras.activeBuffs[spellName] or
+      DoiteTargetAuras.activeDebuffs[spellName] or
+      DoiteTargetAuras.IsHiddenByBuffCap(spellName)
+end
+
+function DoiteTargetAuras.HasBuff(spellName)
+  return DoiteTargetAuras.activeBuffs[spellName] or
+      DoiteTargetAuras.IsHiddenByBuffCap(spellName)
+end
+
+function DoiteTargetAuras.HasDebuff(spellName)
+  return DoiteTargetAuras.activeDebuffs[spellName] or false
+end
+
+function DoiteTargetAuras.GetBuffStacks(spellName)
+  local cachedSlot = DoiteTargetAuras.activeBuffs[spellName]
+  if not cachedSlot then
+    if DoiteTargetAuras.IsHiddenByBuffCap(spellName) then
+      return DoiteTargetAuras.cappedBuffsStacks[spellName]
+    end
+    return nil
+  end
+
+  local spellId = DoiteTargetAuras.spellNameToIdCache[spellName]
+  if not spellId then
+    return nil
+  end
+
+  if DoiteTargetAuras.buffs[cachedSlot] and DoiteTargetAuras.buffs[cachedSlot].spellId == spellId then
+    return DoiteTargetAuras.buffs[cachedSlot].stacks
+  end
+
+  local i
+  for i = 1, MAX_BUFF_SLOTS do
+    if not DoiteTargetAuras.buffs[i].spellId then
+      break
+    end
+    if DoiteTargetAuras.buffs[i].spellId == spellId then
+      return DoiteTargetAuras.buffs[i].stacks
+    end
+  end
+
+  return nil
+end
+
+function DoiteTargetAuras.GetDebuffStacks(spellName)
+  local cachedSlot = DoiteTargetAuras.activeDebuffs[spellName]
+  if not cachedSlot then
+    return nil
+  end
+
+  local spellId = DoiteTargetAuras.spellNameToIdCache[spellName]
+  if not spellId then
+    return nil
+  end
+
+  if DoiteTargetAuras.debuffs[cachedSlot] and DoiteTargetAuras.debuffs[cachedSlot].spellId == spellId then
+    return DoiteTargetAuras.debuffs[cachedSlot].stacks
+  end
+
+  local i
+  for i = 1, MAX_DEBUFF_SLOTS do
+    if not DoiteTargetAuras.debuffs[i].spellId then
+      break
+    end
+    if DoiteTargetAuras.debuffs[i].spellId == spellId then
+      return DoiteTargetAuras.debuffs[i].stacks
+    end
+  end
+
+  return nil
+end
+
+function DoiteTargetAuras.HasBuffSpellId(spellId)
+  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
+  if not spellName then
+    spellName = GetSpellRecField(spellId, "name")
+    if spellName then
+      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
+      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
+    end
+  end
+  if not spellName then
+    return false
+  end
+  return DoiteTargetAuras.HasBuff(spellName)
+end
+
+function DoiteTargetAuras.HasDebuffSpellId(spellId)
+  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
+  if not spellName then
+    spellName = GetSpellRecField(spellId, "name")
+    if spellName then
+      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
+      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
+    end
+  end
+  if not spellName then
+    return false
+  end
+  return DoiteTargetAuras.HasDebuff(spellName)
+end
+
+function DoiteTargetAuras.GetHiddenBuffRemaining(spellName)
+  local expirationTime = DoiteTargetAuras.cappedBuffsExpirationTime[spellName]
+  if expirationTime and expirationTime > 0 then
+    local remaining = expirationTime - GetTime()
+    if remaining > 0 then
+      return remaining
+    end
+    RemoveCappedBuff(spellName)
+  end
+  return nil
+end
+
+local TargetChangedFrame = CreateFrame("Frame", "DoiteTargetAuras_TargetChanged")
+TargetChangedFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+TargetChangedFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+TargetChangedFrame:SetScript("OnEvent", function()
+  UpdateAuras()
+end)
+
+local BuffAddedOtherFrame = CreateFrame("Frame", "DoiteTargetAuras_BuffAddedOther")
+BuffAddedOtherFrame:RegisterEvent("BUFF_ADDED_OTHER")
+BuffAddedOtherFrame:SetScript("OnEvent", function()
+  local guid = arg1
+  if guid ~= DoiteTargetAuras.targetGuid then
+    return
+  end
+
+  local spellId = arg3
+  local stacks = arg4
+  local auraSlot = arg6
+
+  if auraSlot < 0 or auraSlot >= MAX_BUFF_SLOTS then
+    return
+  end
+
+  local slot = auraSlot + 1
+  DoiteTargetAuras.buffs[slot].spellId = spellId
+  DoiteTargetAuras.buffs[slot].stacks = stacks
+  MarkActive(spellId, DoiteTargetAuras.activeBuffs, slot)
+end)
+
+local BuffRemovedOtherFrame = CreateFrame("Frame", "DoiteTargetAuras_BuffRemovedOther")
+BuffRemovedOtherFrame:RegisterEvent("BUFF_REMOVED_OTHER")
+BuffRemovedOtherFrame:SetScript("OnEvent", function()
+  local guid = arg1
+  if guid ~= DoiteTargetAuras.targetGuid then
+    return
+  end
+
+  local spellId = arg3
+  local stacks = arg4
+  local auraSlot = arg6
+  local state = arg7
+
+  if auraSlot < 0 or auraSlot >= MAX_BUFF_SLOTS then
+    return
+  end
+
+  local slot = auraSlot + 1
+  if state == 1 then
+    DoiteTargetAuras.buffs[slot].spellId = nil
+    DoiteTargetAuras.buffs[slot].stacks = nil
+    MarkInactive(spellId, DoiteTargetAuras.activeBuffs)
+  else
+    DoiteTargetAuras.buffs[slot].stacks = stacks
+  end
+end)
+
+local DebuffAddedOtherFrame = CreateFrame("Frame", "DoiteTargetAuras_DebuffAddedOther")
+DebuffAddedOtherFrame:RegisterEvent("DEBUFF_ADDED_OTHER")
+DebuffAddedOtherFrame:SetScript("OnEvent", function()
+  local guid = arg1
+  if guid ~= DoiteTargetAuras.targetGuid then
+    return
+  end
+
+  local spellId = arg3
+  local stacks = arg4
+  local auraSlot = arg6
+
+  if auraSlot < MAX_BUFF_SLOTS or auraSlot >= (MAX_BUFF_SLOTS + MAX_DEBUFF_SLOTS) then
+    return
+  end
+
+  local slot = auraSlot - MAX_BUFF_SLOTS + 1
+  DoiteTargetAuras.debuffs[slot].spellId = spellId
+  DoiteTargetAuras.debuffs[slot].stacks = stacks
+  MarkActive(spellId, DoiteTargetAuras.activeDebuffs, slot)
+end)
+
+local DebuffRemovedOtherFrame = CreateFrame("Frame", "DoiteTargetAuras_DebuffRemovedOther")
+DebuffRemovedOtherFrame:RegisterEvent("DEBUFF_REMOVED_OTHER")
+DebuffRemovedOtherFrame:SetScript("OnEvent", function()
+  local guid = arg1
+  if guid ~= DoiteTargetAuras.targetGuid then
+    return
+  end
+
+  local spellId = arg3
+  local stacks = arg4
+  local auraSlot = arg6
+  local state = arg7
+
+  if auraSlot < MAX_BUFF_SLOTS or auraSlot >= (MAX_BUFF_SLOTS + MAX_DEBUFF_SLOTS) then
+    return
+  end
+
+  local slot = auraSlot - MAX_BUFF_SLOTS + 1
+  if state == 1 then
+    DoiteTargetAuras.debuffs[slot].spellId = nil
+    DoiteTargetAuras.debuffs[slot].stacks = nil
+    MarkInactive(spellId, DoiteTargetAuras.activeDebuffs)
+  else
+    DoiteTargetAuras.debuffs[slot].stacks = stacks
+  end
+end)
+
+local AuraCastOtherFrame = CreateFrame("Frame", "DoiteTargetAuras_AuraCastOther")
+AuraCastOtherFrame:RegisterEvent("AURA_CAST_ON_OTHER")
+AuraCastOtherFrame:SetScript("OnEvent", function()
+  local spellId = arg1
+  local targetGuid = arg3
+  local durationMs = arg8
+  local auraCapStatus = arg9
+
+  if targetGuid ~= DoiteTargetAuras.targetGuid then
+    return
+  end
+
+  if not (auraCapStatus == 1 or auraCapStatus == 3) then
+    return
+  end
+
+  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
+  if not spellName then
+    spellName = GetSpellRecField(spellId, "name")
+    if spellName then
+      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
+      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
+    else
+      return
+    end
+  end
+
+  if not DoiteTargetAuras.spellNameToMaxStacks[spellName] then
+    local maxStacks = GetSpellRecField(spellId, "stackAmount")
+    if maxStacks == 0 then
+      maxStacks = 1
+    end
+    DoiteTargetAuras.spellNameToMaxStacks[spellName] = maxStacks
+  end
+
+  local expirationTime = DoiteTargetAuras.cappedBuffsExpirationTime[spellName]
+  if expirationTime and expirationTime > 0 and expirationTime <= GetTime() then
+    DoiteTargetAuras.cappedBuffsStacks[spellName] = 0
+  end
+
+  DoiteTargetAuras.cappedBuffsExpirationTime[spellName] = GetTime() + durationMs / 1000.0
+
+  local currentStacks = DoiteTargetAuras.cappedBuffsStacks[spellName] or 0
+  local maxStacks = DoiteTargetAuras.spellNameToMaxStacks[spellName] or 1
+  DoiteTargetAuras.cappedBuffsStacks[spellName] = math.min(currentStacks + 1, maxStacks)
+end)

--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -450,6 +450,13 @@ local function _AuraHasSpellId(unit, spellId, isDebuff)
     return false
   end
 
+  if unit == "target" and DoiteTargetAuras then
+    if isDebuff then
+      return DoiteTargetAuras.HasDebuffSpellId(spellId)
+    end
+    return DoiteTargetAuras.HasBuffSpellId(spellId)
+  end
+
   local auras = _GetUnitAuraTable(unit, isDebuff)
   if type(auras) ~= "table" then
     return false


### PR DESCRIPTION
### Motivation
- Provide a target-oriented aura cache equivalent to the existing player aura helper so aura conditions can evaluate target buffs/debuffs (including buff-cap overflow) more efficiently.
- Move target-related aura logic out of player-specific helpers to centralize target stack/slot lookups and Nampower event handling.

### Description
- Added a new module `Modules/DoiteTargetAuras.lua` that mirrors the player aura cache API but tracks the current `target` GUID, target buff/debuff slots, stack counts, spell-id/name caches, and handles `*_OTHER`/`AURA_CAST_ON_OTHER` events and buff-cap overflow bookkeeping.
- Registered the new module in the addon file list by adding `Modules\DoiteTargetAuras.lua` to `DoiteAuras.toc` so it loads with the addon.
- Updated `Modules/DoiteConditions.lua` to use `DoiteTargetAuras` for aura presence, overflow-aware debuff checks, stack lookups, and remaining-time queries where target semantics are intended, and remapped legacy `player`-unit checks in the aura branch to target semantics for this flow.
- Updated `Modules/DoiteTrack.lua` so `_AuraHasSpellId` consults `DoiteTargetAuras` for `target` spell-id presence (buff/debuff) before falling back to the generic unit-field scan.

### Testing
- Verified the new module file exists and has content by listing and previewing `Modules/DoiteTargetAuras.lua` (file present, ~415 lines) which succeeded.
- Performed static repository checks using `rg` to find and validate references to `DoiteTargetAuras` and replaced player-oriented calls in `DoiteConditions.lua` and `DoiteTrack.lua`, and inspected diffs to ensure the intended wiring changes were applied successfully.
- Displayed the modified `DoiteAuras.toc` and key diffs to confirm the new module is included and the condition/track changes are present, all checks succeeded.
- Attempted to run a Lua runtime check with `lua -v` but a Lua binary was not available in this environment, so runtime syntax execution was not performed (tooling checks were limited to static inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995b3e977f0832abfb999a163e37f3c)