### PR TITLE
Avoid duplicate condition evaluations after DoiteTargetAuras immediate refresh

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -196,6 +196,15 @@ _DoiteImmediateEval:SetScript("OnUpdate", function()
 
   if DoiteConditions and DoiteConditions.EvaluateAll then
     DoiteConditions:EvaluateAll()
+
+    -- Avoid a second full pass in the normal OnUpdate loop right after
+    -- this immediate evaluation. Target aura updates already arrive through
+    -- DoiteTargetAuras and are handled here, so keep the dirty state clean.
+    dirty_ability = false
+    dirty_aura = false
+    dirty_target = false
+    dirty_power = false
+    dirty_ability_time = false
   end
 
   if DoiteGroup then


### PR DESCRIPTION
### Motivation
- DoiteTargetAuras is the canonical source for target auras and requests an immediate condition evaluation when the target cache changes, so the normal OnUpdate loop should not re-run a full pass immediately afterwards.
- Prevent duplicate evaluations and ensure DoiteTargetAuras' optimization (cache/overflow handling) is not negated by leftover dirty flags in DoiteConditions.

### Description
- Clear the DoiteConditions dirty flags (`dirty_ability`, `dirty_aura`, `dirty_target`, `dirty_power`, `dirty_ability_time`) immediately after calling `DoiteConditions:EvaluateAll()` in the `_DoiteImmediateEval` OnUpdate handler so the normal update loop does not perform a redundant full evaluation.
- Confirmed `DoiteConditions` uses `DoiteTargetAuras` for target aura presence and stacks, and `DoiteTrack` uses `DoiteTargetAuras` for spellId presence checks, and left `DoitePlayerAuras` and `DoiteTargetAuras` unchanged as requested.

### Testing
- Static code inspections via pattern searches to verify `DoiteTargetAuras` is referenced from `DoiteConditions` and `DoiteTrack` succeeded.
- Patch application succeeded and the modified file shows the intended insertion in `Modules/DoiteConditions.lua`.
- Code style / diff checks (`diff --check` / status) completed without reported issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6996444a533c832a8684404c6af6b205)