### PR TITLE
Consolidate duplicated UI helpers and remove dead local functions

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -1373,21 +1373,6 @@ function DoiteAuras_GetIconFrame(key)
     return f
 end
 
-local function GetIconLayout(key)
-    if DoiteDB and DoiteDB.icons and DoiteDB.icons[key] then
-        return DoiteDB.icons[key]
-    end
-    return nil
-end
-
--- helper to get data
-local function GetSpellData(key)
-  if not DoiteAurasDB.spells[key] then
-    DoiteAurasDB.spells[key] = {}
-  end
-  return DoiteAurasDB.spells[key]
-end
-
 -- Helpers
 local function GetOrderedSpells()
     local list = {}
@@ -1531,76 +1516,6 @@ local function DoiteAuras_IsKeyDisabled(key)
     return DA_IsBucketDisabled(bucketKey)
 end
 _G["DoiteAuras_IsKeyDisabled"] = DoiteAuras_IsKeyDisabled
-
--- When the last icon in a group/category is removed, clear
-local function DA_CleanupEmptyGroupAndCategory(groupName, categoryName)
-    if not DoiteAurasDB or not DoiteAurasDB.spells then
-        return
-    end
-
-    -- Normalize sentinels
-    if groupName == "" or groupName == "no" then
-        groupName = nil
-    end
-    if categoryName == "" or categoryName == "no" then
-        categoryName = nil
-    end
-
-    if not groupName and not categoryName then
-        return
-    end
-
-    local hasGroup = false
-    local hasCategory = false
-
-    -- Scan remaining icons to see if any still reference this group/category
-    local k, d
-    for k, d in pairs(DoiteAurasDB.spells) do
-        if d then
-            if groupName and not hasGroup and d.group == groupName then
-                hasGroup = true
-            end
-            if categoryName and not hasCategory and d.category == categoryName then
-                hasCategory = true
-            end
-            if (not groupName or hasGroup) and (not categoryName or hasCategory) then
-                break
-            end
-        end
-    end
-
-    -- If no icons left in this group: drop its sort mode + disabled flag
-    if groupName and not hasGroup then
-        if DoiteAurasDB.groupSort then
-            DoiteAurasDB.groupSort[groupName] = nil
-        end
-        if DoiteAurasDB.bucketDisabled then
-            DoiteAurasDB.bucketDisabled[groupName] = nil
-        end
-        DoiteGroup.InvalidateSortCache(groupName)
-    end
-
-    -- If no icons left with this category: remove it from the global list
-    if categoryName and not hasCategory then
-        local list = DoiteAurasDB.categories
-        if list then
-            local i = 1
-            local n = table.getn(list)
-            while i <= n do
-                if list[i] == categoryName then
-                    table.remove(list, i)
-                    n = n - 1
-                else
-                    i = i + 1
-                end
-            end
-        end
-
-        if DoiteAurasDB.bucketDisabled then
-            DoiteAurasDB.bucketDisabled[categoryName] = nil
-        end
-    end
-end
 
 local function DA_BuildDisplayList(ordered)
     local groupedByName      = {}
@@ -1882,35 +1797,6 @@ local function FindSpellBookSlot(spellName)
         end
     end
     return nil
-end
-
--- Buff/Debuff check via tooltip
-local function FindPlayerBuff(name)
-    local i=1
-    while true do
-        local bname = GetBuffName("player", i, false)
-        if not bname then break end
-        if bname == name then
-            local tex = UnitBuff("player", i)
-            return true, tex
-        end
-        i=i+1
-    end
-    return false,nil
-end
-
-local function FindPlayerDebuff(name)
-    local i=1
-    while true do
-        local dname = GetBuffName("player", i, true)
-        if not dname then break end
-        if dname == name then
-            local tex = UnitDebuff("player", i)
-            return true, tex
-        end
-        i=i+1
-    end
-    return false,nil
 end
 
 -- Helper: Use item by name scanning bags/inventory
@@ -3639,12 +3525,6 @@ local function DA_GetVersion_Safe()
   end
   local v = (GetAddOnMetadata and GetAddOnMetadata("DoiteAuras", "Version")) or (DoiteAuras_Version) or "?"
   return v or "?"
-end
-
--- Broadcast helpers
-local function DA_BroadcastVersion(channel)
-  if not SendAddonMessage then return end
-  SendAddonMessage(DA_PREFIX, "DA_VER:" .. tostring(DA_GetVersion_Safe()), channel)
 end
 
 local function DA_BroadcastVersionAll()

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -41,6 +41,54 @@ local function _IsRogueOrDruid()
   return (c == "ROGUE" or c == "DRUID")
 end
 
+local function DoiteEdit_YellowifyButton(btn)
+  if not btn then
+    return
+  end
+  if btn.SetNormalFontObject then
+    btn:SetNormalFontObject("GameFontNormalSmall")
+  end
+  local fs = btn:GetFontString()
+  if fs and fs.SetTextColor then
+    fs:SetTextColor(1, 0.82, 0)
+  end
+end
+
+local function DoiteEdit_EnableCheck(cb)
+  if not cb then
+    return
+  end
+  cb:Enable()
+  if cb.text and cb.text.SetTextColor then
+    cb.text:SetTextColor(1, 0.82, 0)
+  end
+end
+
+local function DoiteEdit_DisableCheck(cb)
+  if not cb then
+    return
+  end
+  cb:Disable()
+  if cb.text and cb.text.SetTextColor then
+    cb.text:SetTextColor(0.6, 0.6, 0.6)
+  end
+end
+
+local function DoiteEdit_AddGroupModeOption(typeKey, text, value)
+  local info = UIDropDownMenu_CreateInfo()
+  info.text = text
+  info.value = value
+  info.func = function(button)
+    local v = (button and button.value) or value
+    if v == "__default" then
+      SetGroupMode(typeKey, nil)
+    else
+      SetGroupMode(typeKey, v)
+    end
+  end
+  UIDropDownMenu_AddButton(info)
+end
+
 -- === Lightweight throttle for heavy UI work (prevents lag while dragging sliders) ===
 local _DoiteEdit_PendingHeavy = false
 local _DoiteEdit_Accum = 0
@@ -1579,27 +1627,11 @@ local function CreateConditionsUI()
 
     ClearDropdown(condFrame.cond_ability_groupingDD)
     UIDropDownMenu_Initialize(condFrame.cond_ability_groupingDD, function(frame, level, menuList)
-      local dd = condFrame.cond_ability_groupingDD
-      local function _Add(text, value)
-        local info = UIDropDownMenu_CreateInfo()
-        info.text = text
-        info.value = value
-        info.func = function(button)
-          local v = (button and button.value) or value
-          if v == "__default" then
-            SetGroupMode("ability", nil)
-          else
-            SetGroupMode("ability", v)
-          end
-        end
-        UIDropDownMenu_AddButton(info)
-      end
-
-      _Add("Any", "any")
-      _Add("Not in group", "nogroup")
-      _Add("In party", "party")
-      _Add("In raid", "raid")
-      _Add("In party or raid", "partyraid")
+      DoiteEdit_AddGroupModeOption("ability", "Any", "any")
+      DoiteEdit_AddGroupModeOption("ability", "Not in group", "nogroup")
+      DoiteEdit_AddGroupModeOption("ability", "In party", "party")
+      DoiteEdit_AddGroupModeOption("ability", "In raid", "raid")
+      DoiteEdit_AddGroupModeOption("ability", "In party or raid", "partyraid")
     end)
   end
 
@@ -1743,27 +1775,11 @@ local function CreateConditionsUI()
 
     ClearDropdown(condFrame.cond_aura_groupingDD)
     UIDropDownMenu_Initialize(condFrame.cond_aura_groupingDD, function(frame, level, menuList)
-      local dd = condFrame.cond_aura_groupingDD
-      local function _Add(text, value)
-        local info = UIDropDownMenu_CreateInfo()
-        info.text = text
-        info.value = value
-        info.func = function(button)
-          local v = (button and button.value) or value
-          if v == "__default" then
-            SetGroupMode("aura", nil)
-          else
-            SetGroupMode("aura", v)
-          end
-        end
-        UIDropDownMenu_AddButton(info)
-      end
-
-      _Add("Any", "any")
-      _Add("Not in group", "nogroup")
-      _Add("In party", "party")
-      _Add("In raid", "raid")
-      _Add("In party or raid", "partyraid")
+      DoiteEdit_AddGroupModeOption("aura", "Any", "any")
+      DoiteEdit_AddGroupModeOption("aura", "Not in group", "nogroup")
+      DoiteEdit_AddGroupModeOption("aura", "In party", "party")
+      DoiteEdit_AddGroupModeOption("aura", "In raid", "raid")
+      DoiteEdit_AddGroupModeOption("aura", "In party or raid", "partyraid")
     end)
   end
 
@@ -1951,27 +1967,11 @@ local function CreateConditionsUI()
 
     ClearDropdown(condFrame.cond_item_groupingDD)
     UIDropDownMenu_Initialize(condFrame.cond_item_groupingDD, function(frame, level, menuList)
-      local dd = condFrame.cond_item_groupingDD
-      local function _Add(text, value)
-        local info = UIDropDownMenu_CreateInfo()
-        info.text = text
-        info.value = value
-        info.func = function(button)
-          local v = (button and button.value) or value
-          if v == "__default" then
-            SetGroupMode("item", nil)
-          else
-            SetGroupMode("item", v)
-          end
-        end
-        UIDropDownMenu_AddButton(info)
-      end
-
-      _Add("Any", "any")
-      _Add("Not in group", "nogroup")
-      _Add("In party", "party")
-      _Add("In raid", "raid")
-      _Add("In party or raid", "partyraid")
+      DoiteEdit_AddGroupModeOption("item", "Any", "any")
+      DoiteEdit_AddGroupModeOption("item", "Not in group", "nogroup")
+      DoiteEdit_AddGroupModeOption("item", "In party", "party")
+      DoiteEdit_AddGroupModeOption("item", "In raid", "raid")
+      DoiteEdit_AddGroupModeOption("item", "In party or raid", "partyraid")
     end)
   end
 
@@ -5716,10 +5716,6 @@ do
     local closeWidth = row._closeWidth or 20
     local okWidth = row._okWidth or 20
   
-    -- keep old name used below, but make it safe (no rebuild)
-    local function UpdateStacksVisibility()
-      AuraCond_UpdateStacksUI(row)
-    end
   
     if state == "STEP1" then
       row._branch = nil
@@ -5833,7 +5829,7 @@ do
         row.stacksValEnter:SetPoint("LEFT", row.stacksVal, "RIGHT", 4, 0)
       end
   
-      UpdateStacksVisibility()
+      AuraCond_UpdateStacksUI(row)
   
     elseif state == "INPUT" then
       local addWidth = row.addButton:GetWidth() or 40
@@ -6271,25 +6267,12 @@ do
 
     row.closeBtn:SetText("X")
 
-    local function YellowifyButton(btn)
-      if not btn then
-        return
-      end
-      if btn.SetNormalFontObject then
-        btn:SetNormalFontObject("GameFontNormalSmall")
-      end
-      local fs = btn:GetFontString()
-      if fs and fs.SetTextColor then
-        fs:SetTextColor(1, 0.82, 0)
-      end
-    end
-
-    YellowifyButton(row.btn1)
-    YellowifyButton(row.btn2)
-    YellowifyButton(row.btn3)
-    YellowifyButton(row.addButton)
-    YellowifyButton(row.closeBtn)
-	YellowifyButton(row.okBtn)
+    DoiteEdit_YellowifyButton(row.btn1)
+    DoiteEdit_YellowifyButton(row.btn2)
+    DoiteEdit_YellowifyButton(row.btn3)
+    DoiteEdit_YellowifyButton(row.addButton)
+    DoiteEdit_YellowifyButton(row.closeBtn)
+	DoiteEdit_YellowifyButton(row.okBtn)
 
     -- progression buttons:
     row.btn1:SetScript("OnClick", function()
@@ -6661,13 +6644,6 @@ do
   end
 
 
-  local function VfxCond_Len(t)
-    if not t then return 0 end
-    local n = 0
-    for _ in pairs(t) do n = n + 1 end
-    return n
-  end
-
   local function VfxCond_TitleCase(str)
     if not str then
       return ""
@@ -6972,10 +6948,6 @@ do
     local parentWidth = row._parentWidth or 260
     local closeWidth = row._closeWidth or 20
   
-    local function UpdateStacksVisibility()
-      VfxCond_UpdateStacksUI(row)
-    end
-  
     if state == "STEP1" then
       row._branch = nil
       local available = parentWidth - closeWidth - spacing * 5
@@ -7088,7 +7060,7 @@ do
         row.stacksValEnter:SetPoint("LEFT", row.stacksVal, "RIGHT", 4, 0)
       end
   
-      UpdateStacksVisibility()
+      VfxCond_UpdateStacksUI(row)
   
     elseif state == "INPUT" then
       local addWidth = row.addButton:GetWidth() or 40
@@ -7510,19 +7482,12 @@ do
 
     row.closeBtn:SetText("X")
 
-    local function YellowifyButton(btn)
-      if not btn then return end
-      if btn.SetNormalFontObject then btn:SetNormalFontObject("GameFontNormalSmall") end
-      local fs = btn:GetFontString()
-      if fs and fs.SetTextColor then fs:SetTextColor(1, 0.82, 0) end
-    end
-
-	YellowifyButton(row.btn1)
-	YellowifyButton(row.btn2)
-	YellowifyButton(row.btn3)
-	YellowifyButton(row.addButton)
-	YellowifyButton(row.closeBtn)
-	YellowifyButton(row.okBtn)
+	DoiteEdit_YellowifyButton(row.btn1)
+	DoiteEdit_YellowifyButton(row.btn2)
+	DoiteEdit_YellowifyButton(row.btn3)
+	DoiteEdit_YellowifyButton(row.addButton)
+	DoiteEdit_YellowifyButton(row.closeBtn)
+	DoiteEdit_YellowifyButton(row.okBtn)
 
     -- Button click handlers
     row.btn1:SetScript("OnClick", function()
@@ -8133,36 +8098,24 @@ local function UpdateConditionsUI(data)
     end
 
     -- Row 10: Text flag (time remaining only; abilities never have a stack text)
-    local function _enableCheck(cb)
-      cb:Enable()
-      if cb.text and cb.text.SetTextColor then
-        cb.text:SetTextColor(1, 0.82, 0)
-      end
-    end
-    local function _disableCheck(cb)
-      cb:Disable()
-      if cb.text and cb.text.SetTextColor then
-        cb.text:SetTextColor(0.6, 0.6, 0.6)
-      end
-    end
 
     -- Time remaining behaves as before (gated by slider when mode is usable/notcd; shown on 'oncd')
     if mode == "oncd" then
       condFrame.cond_ability_text_time:Show()
-      _enableCheck(condFrame.cond_ability_text_time)
+      DoiteEdit_EnableCheck(condFrame.cond_ability_text_time)
       condFrame.cond_ability_text_time:SetChecked((c.ability and c.ability.textTimeRemaining) or false)
 
     elseif mode == "usable" or mode == "notcd" then
       condFrame.cond_ability_text_time:Show()
       if slidEnabled then
-        _enableCheck(condFrame.cond_ability_text_time)
+        DoiteEdit_EnableCheck(condFrame.cond_ability_text_time)
         condFrame.cond_ability_text_time:SetChecked((c.ability and c.ability.textTimeRemaining) or false)
       else
         if c.ability and c.ability.textTimeRemaining then
           c.ability.textTimeRemaining = false
         end
         condFrame.cond_ability_text_time:SetChecked(false)
-        _disableCheck(condFrame.cond_ability_text_time)
+        DoiteEdit_DisableCheck(condFrame.cond_ability_text_time)
       end
     else
       condFrame.cond_ability_text_time:Hide()
@@ -9330,18 +9283,6 @@ local ic = c.item or {}
     end
 
     -- small helpers used in this branch only
-    local function _enableCheck(cb)
-      cb:Enable()
-      if cb.text and cb.text.SetTextColor then
-        cb.text:SetTextColor(1, 0.82, 0)
-      end
-    end
-    local function _disableCheck(cb)
-      cb:Disable()
-      if cb.text and cb.text.SetTextColor then
-        cb.text:SetTextColor(0.6, 0.6, 0.6)
-      end
-    end
     local function _enableDD(dd)
       if not dd then
         return
@@ -9692,7 +9633,7 @@ local ic = c.item or {}
     if amode == "found" then
       -- === Text: Stack counter ===
       condFrame.cond_aura_text_stack:Show()
-      _enableCheck(condFrame.cond_aura_text_stack)
+      DoiteEdit_EnableCheck(condFrame.cond_aura_text_stack)
       condFrame.cond_aura_text_stack:SetChecked((c.aura and c.aura.textStackCounter) or false)
 
       -- === Text: Time remaining ===
@@ -9700,13 +9641,13 @@ local ic = c.item or {}
 
       if isSelfOnly then
         -- On Player (self): user may freely toggle Text: Remaining
-        _enableCheck(condFrame.cond_aura_text_time)
+        DoiteEdit_EnableCheck(condFrame.cond_aura_text_time)
         condFrame.cond_aura_text_time:SetChecked((c.aura and c.aura.textTimeRemaining) or false)
 
       elseif isHelpOrHarm then
         if onlyMine then
           -- My Aura checked -> user controls Text: Remaining
-          _enableCheck(condFrame.cond_aura_text_time)
+          DoiteEdit_EnableCheck(condFrame.cond_aura_text_time)
           condFrame.cond_aura_text_time:SetChecked((c.aura and c.aura.textTimeRemaining) or false)
         else
           -- My Aura NOT checked -> Text: Remaining forced OFF and greyed
@@ -9714,11 +9655,11 @@ local ic = c.item or {}
             c.aura.textTimeRemaining = false
           end
           condFrame.cond_aura_text_time:SetChecked(false)
-          _disableCheck(condFrame.cond_aura_text_time)
+          DoiteEdit_DisableCheck(condFrame.cond_aura_text_time)
         end
       else
         -- Fallback: disable
-        _disableCheck(condFrame.cond_aura_text_time)
+        DoiteEdit_DisableCheck(condFrame.cond_aura_text_time)
         condFrame.cond_aura_text_time:SetChecked(false)
         if c.aura and c.aura.textTimeRemaining then
           c.aura.textTimeRemaining = false
@@ -9730,8 +9671,8 @@ local ic = c.item or {}
       condFrame.cond_aura_text_stack:Show()
       condFrame.cond_aura_text_time:Show()
 
-      _disableCheck(condFrame.cond_aura_text_stack)
-      _disableCheck(condFrame.cond_aura_text_time)
+      DoiteEdit_DisableCheck(condFrame.cond_aura_text_stack)
+      DoiteEdit_DisableCheck(condFrame.cond_aura_text_time)
 
       condFrame.cond_aura_text_stack:SetChecked(false)
       condFrame.cond_aura_text_time:SetChecked(false)
@@ -9804,14 +9745,14 @@ local ic = c.item or {}
 
       if isSelfOnly then
         -- On Player (self): user can freely toggle Remaining
-        _enableCheck(condFrame.cond_aura_remaining_cb)
+        DoiteEdit_EnableCheck(condFrame.cond_aura_remaining_cb)
         condFrame.cond_aura_remaining_cb:SetChecked(aRemEnabled)
 
       elseif isHelpOrHarm then
         -- Help/Harm target: apply My Aura rules
         if onlyMine then
           -- My Aura checked -> user controls Remaining
-          _enableCheck(condFrame.cond_aura_remaining_cb)
+          DoiteEdit_EnableCheck(condFrame.cond_aura_remaining_cb)
           condFrame.cond_aura_remaining_cb:SetChecked(aRemEnabled)
         else
           -- My Aura NOT checked -> Remaining disabled and cleared
@@ -9820,11 +9761,11 @@ local ic = c.item or {}
           end
           aRemEnabled = false
           condFrame.cond_aura_remaining_cb:SetChecked(false)
-          _disableCheck(condFrame.cond_aura_remaining_cb)
+          DoiteEdit_DisableCheck(condFrame.cond_aura_remaining_cb)
         end
       else
         -- Fallback: disable
-        _disableCheck(condFrame.cond_aura_remaining_cb)
+        DoiteEdit_DisableCheck(condFrame.cond_aura_remaining_cb)
         condFrame.cond_aura_remaining_cb:SetChecked(false)
         if c.aura then
           c.aura.remainingEnabled = false
@@ -9855,7 +9796,7 @@ local ic = c.item or {}
         condFrame.cond_aura_remaining_cb.text:SetText("Remaining")
       end
 
-      _disableCheck(condFrame.cond_aura_remaining_cb)
+      DoiteEdit_DisableCheck(condFrame.cond_aura_remaining_cb)
       condFrame.cond_aura_remaining_cb:SetChecked(false)
       if c.aura then
         c.aura.remainingEnabled = false
@@ -9871,7 +9812,7 @@ local ic = c.item or {}
     condFrame.cond_aura_stacks_cb:SetChecked(aStacksEnabled)
     if amode == "found" then
       condFrame.cond_aura_stacks_cb:Show()
-      _enableCheck(condFrame.cond_aura_stacks_cb)
+      DoiteEdit_EnableCheck(condFrame.cond_aura_stacks_cb)
       if aStacksEnabled then
         condFrame.cond_aura_stacks_comp:Show()
         condFrame.cond_aura_stacks_val:Show()
@@ -9890,7 +9831,7 @@ local ic = c.item or {}
       -- Aura missing or no mode: show but disabled/cleared for MISSING, hide for nil-mode
       if amode == "missing" then
         condFrame.cond_aura_stacks_cb:Show()
-        _disableCheck(condFrame.cond_aura_stacks_cb)
+        DoiteEdit_DisableCheck(condFrame.cond_aura_stacks_cb)
         condFrame.cond_aura_stacks_cb:SetChecked(false)
         if c.aura then
           c.aura.stacksEnabled = false

--- a/docs/lua-health-review.md
+++ b/docs/lua-health-review.md
@@ -1,0 +1,68 @@
+# Lua health review: `Modules/DoiteEdit.lua` and `DoiteAuras.lua`
+
+## Scope
+- Reviewed for duplication, dead/unbound code, and general maintainability risks.
+
+## `Modules/DoiteEdit.lua`
+
+### Overall
+- **Functional but very large/complex** (~11k lines) and contains several repeated helper blocks that increase maintenance cost.
+- The file appears to be **working code with technical debt**, not a broken file.
+
+### Findings
+1. **Duplicated helper function names/blocks in multiple places** (mostly UI branch-local helpers):
+   - `_Add` appears repeatedly in dropdown initializers for different sections (`ability`, `aura`, etc.).
+   - `UpdateStacksVisibility` appears in both aura and VFX row-state handlers.
+   - `YellowifyButton` appears in multiple row-build sections.
+   - `_enableCheck` / `_disableCheck` exist in at least two branch-local blocks with identical logic.
+
+2. **Potentially dead/shadowed local function**:
+   - `VfxCond_Len` is defined twice in the same scope area; the second definition overwrites the first, so the first one is effectively dead from that point onward.
+
+3. **Architecture smell**:
+   - The file intermixes UI construction, per-type condition logic, rendering, and behavior wiring in one module; this is likely why it *feels* messy.
+
+### Risk assessment
+- **High maintenance risk, moderate bug risk**:
+  - Copy-pasted helpers can drift over time and cause subtle inconsistencies.
+  - Shadowed redefinitions can hide intent and make debugging harder.
+
+### Recommended cleanup order
+1. Extract repeated tiny helpers once at module scope (e.g., check-enable/disable, button-yellow styling, dropdown item adder).
+2. Resolve duplicate `VfxCond_Len` by keeping one canonical implementation.
+3. Split this file by concern (row builders, shared UI helpers, aura condition workflow, vfx workflow).
+
+---
+
+## `DoiteAuras.lua`
+
+### Overall
+- **Healthier than `DoiteEdit.lua`** despite being large (~3.9k lines).
+- Structure is more modular with named helpers and clear sections.
+
+### Findings
+1. **No repeated function-name definitions detected** in this file (good sign compared to `DoiteEdit.lua`).
+2. **Likely dead local helpers** (declared but not referenced later in-file):
+   - `GetIconLayout`
+   - `GetSpellData`
+   - `DA_CleanupEmptyGroupAndCategory`
+   - `FindPlayerBuff`
+   - `FindPlayerDebuff`
+   - `DA_BroadcastVersion` (while `DA_BroadcastVersionAll` is used)
+3. The file still has broad responsibility (UI, caching, command handlers, networking/version checks), but with better helper boundaries.
+
+### Risk assessment
+- **Moderate maintenance risk, low-to-moderate bug risk**:
+  - Dead helpers increase cognitive load and make readers hunt for usage that never comes.
+  - Otherwise, helper decomposition and guard patterns are reasonably healthy.
+
+### Recommended cleanup order
+1. Remove or wire currently-unused local helpers.
+2. Keep section boundaries but consider splitting by subsystem (UI/list, icon refresh/runtime, slash commands/version messaging).
+3. Add a lightweight static check step in workflow (even a custom grep/rg-based lint script) to catch unused locals and duplicate local function names.
+
+---
+
+## Bottom line
+- `DoiteEdit.lua`: **messy-but-salvageable**, with real duplication and at least one shadowed/dead local redefinition.
+- `DoiteAuras.lua`: **mostly healthy for its size**, with a handful of likely dead helper functions to prune.


### PR DESCRIPTION
### Motivation
- Clean up duplication and dead/shadowed local helper functions discovered during the Lua health review to reduce maintenance cost and risk of subtle bugs. 
- Centralize small UI helper logic (button styling, checkbox enable/disable, dropdown item addition) so branches no longer reimplement identical behavior.
- Remove unused local functions from `DoiteAuras.lua` that were declared but not referenced to reduce noise and cognitive load.

### Description
- Added module-level helpers in `Modules/DoiteEdit.lua`: `DoiteEdit_YellowifyButton`, `DoiteEdit_EnableCheck`, `DoiteEdit_DisableCheck`, and `DoiteEdit_AddGroupModeOption`, and replaced multiple branch-local duplicates with calls to these helpers. 
- Replaced branch-local `_Add` dropdown factories with `DoiteEdit_AddGroupModeOption` usages in the `ability`, `aura`, and `item` grouping dropdowns. 
- Removed redundant local wrapper functions for stacks visibility and replaced them with direct calls to `AuraCond_UpdateStacksUI(row)` and `VfxCond_UpdateStacksUI(row)`. 
- Eliminated dead/unused local helpers from `DoiteAuras.lua`: `GetIconLayout`, `GetSpellData`, `DA_CleanupEmptyGroupAndCategory`, `FindPlayerBuff`, `FindPlayerDebuff`, and `DA_BroadcastVersion`, and kept the canonical `DA_BroadcastVersionAll`/version helpers.

### Testing
- Ran targeted `rg` searches (e.g. `rg -n "local function (GetIconLayout|GetSpellData|DA_CleanupEmptyGroupAndCategory|FindPlayerBuff|FindPlayerDebuff|DA_BroadcastVersion)\b" DoiteAuras.lua` and related patterns against `Modules/DoiteEdit.lua`) to confirm removed declarations no longer appear, and these checks succeeded. 
- Executed a Python duplicate-function-name scan that enumerates `local function` and `function` definitions to ensure no duplicate local function names remain, and the scan reports zero remaining duplicates. 
- Performed spot inspections (`nl`/`sed`) of changed regions to validate replacements (helper calls substituted and single canonical `VfxCond_Len` retained), and the inspections matched the intended edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699829514b10832aa4a0369b436e477e)