### PR TITLE
Fix target aura owner filtering race and self-target refresh gap

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -5089,12 +5089,15 @@ local function CheckAuraConditions(data)
     if ownerUnit then
       local _, _, _, isMine, isOther, mineKnown = _DoiteTrackAuraOwnership(name, ownerUnit)
 
-      if mineKnown then
-        if ownerFilter == "mine" and not isMine then
-          found = false
-        elseif ownerFilter == "others" and not isOther then
-          found = false
-        end
+      if not mineKnown then
+        -- Ownership-gated entries should fail closed when DoiteTrack
+        -- cannot classify the aura owner yet. This prevents both
+        -- "onlyMine" and "onlyOthers" variants from showing together.
+        found = false
+      elseif ownerFilter == "mine" and not isMine then
+        found = false
+      elseif ownerFilter == "others" and not isOther then
+        found = false
       end
     end
   end

--- a/Modules/DoiteTargetAuras.lua
+++ b/Modules/DoiteTargetAuras.lua
@@ -166,6 +166,15 @@ local function UpdateTargetGuid()
   return SetTargetGuid(guid)
 end
 
+local function IsCurrentTargetPlayer()
+  if not DoiteTargetAuras.targetGuid or DoiteTargetAuras.targetGuid == "" then
+    return false
+  end
+
+  local _, playerGuid = UnitExists("player")
+  return playerGuid and DoiteTargetAuras.targetGuid == playerGuid
+end
+
 local function UpdateAuras()
   CleanupGuidCaches()
 
@@ -389,6 +398,22 @@ local TargetChangedFrame = CreateFrame("Frame", "DoiteTargetAuras_TargetChanged"
 TargetChangedFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 TargetChangedFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 TargetChangedFrame:SetScript("OnEvent", function()
+  UpdateAuras()
+  NotifyConditionsChanged()
+end)
+
+-- Self aura NP events are required when player is the current target.
+-- In that case, *_OTHER events do not fire, so refresh target cache directly.
+local SelfAuraFrame = CreateFrame("Frame", "DoiteTargetAuras_SelfAura")
+SelfAuraFrame:RegisterEvent("BUFF_ADDED_SELF")
+SelfAuraFrame:RegisterEvent("BUFF_REMOVED_SELF")
+SelfAuraFrame:RegisterEvent("DEBUFF_ADDED_SELF")
+SelfAuraFrame:RegisterEvent("DEBUFF_REMOVED_SELF")
+SelfAuraFrame:SetScript("OnEvent", function()
+  if not IsCurrentTargetPlayer() then
+    return
+  end
+
   UpdateAuras()
   NotifyConditionsChanged()
 end)


### PR DESCRIPTION
### Motivation
- Prevent transient incorrect icon visibility where `onlyMine` and `onlyOthers` target aura icons can both show during brief DoiteTrack classification gaps, and ensure target-aura state updates immediately when the player is the current target.

### Description
- Make ownership-gated aura checks fail closed when `DoiteTrack` cannot yet classify the aura owner so `onlyMine` / `onlyOthers` entries do not both pass (change in `Modules/DoiteConditions.lua`).
- Add `IsCurrentTargetPlayer()` helper and a `SelfAuraFrame` that registers `BUFF_ADDED_SELF`, `BUFF_REMOVED_SELF`, `DEBUFF_ADDED_SELF`, and `DEBUFF_REMOVED_SELF` and calls `UpdateAuras()` and `NotifyConditionsChanged()` when the current target is the player to refresh target cache immediately (change in `Modules/DoiteTargetAuras.lua`).
- Preserve existing behavior when ownership is known; self-aura updates are gated to only run when target GUID equals player GUID to avoid extra work.

### Testing
- Ran repository searches (`rg`) and file inspections (`sed`) to confirm call sites and insertion points, and reviewed the output diffs with `git diff`, which succeeded.
- Applied the patch via `apply_patch` and verified file updates, then ran `git status` and committed the changes successfully.
- Created PR metadata via `make_pr`; there are no unit tests in-repo for in-game behavior so no automated runtime tests were executed against the WoW environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699841b10ea4832ab64f0927dc06ff7f)