### PR TITLE
Clean dead/duplicate logic in DoiteLogic and DoiteTrack

### DIFF
--- a/Modules/DoiteGroup.lua
+++ b/Modules/DoiteGroup.lua
@@ -69,15 +69,6 @@ local function GetGroupFixedMode(groupName, leaderData)
   return false
 end
 
-local function _ClearMap(t)
-  if not t then
-    return
-  end
-  for k in pairs(t) do
-    t[k] = nil
-  end
-end
-
 local function _ComputeOffset(baseX, baseY, growth, pad, steps)
   local x = baseX
   local y = baseY

--- a/Modules/DoiteLogic.lua
+++ b/Modules/DoiteLogic.lua
@@ -206,6 +206,7 @@ local _precedence = {
 local _DA_TMP_RPN_OUT = {}
 local _DA_TMP_OP_STACK = {}
 local _DA_TMP_EVAL_STACK = {}
+local _DA_TMP_TOKENS = {}
 
 local function _DA_WipeArray(t)
   local i = _len(t)
@@ -334,6 +335,17 @@ local function _EvalRpn(rpn, st)
   return (st[1] == true)
 end
 
+local function _EvaluateStrictAnd(list, n, evalFunc)
+  local i = 1
+  while i <= n do
+    if not evalFunc(list[i]) then
+      return false
+    end
+    i = i + 1
+  end
+  return true
+end
+
 ---------------------------------------------------------------
 -- Generic evaluator
 ---------------------------------------------------------------
@@ -352,14 +364,7 @@ function DoiteLogic.EvaluateGeneric(list, evalFunc)
   end
 
   if not _HasAnyLogicHints(list) then
-    local i = 1
-    while i <= n do
-      if not evalFunc(list[i]) then
-        return false
-      end
-      i = i + 1
-    end
-    return true
+    return _EvaluateStrictAnd(list, n, evalFunc)
   end
 
   if _HasAnyParenHints(list) and not _IsParenStructureValid(list) then
@@ -367,23 +372,11 @@ function DoiteLogic.EvaluateGeneric(list, evalFunc)
     _NotifyLogicResetForCurrentSpell()
 
     -- After reset there are no logic hints anymore, so fall back to the simple AND behaviour.
-    local i = 1
-    while i <= n do
-      if not evalFunc(list[i]) then
-        return false
-      end
-      i = i + 1
-    end
-    return true
+    return _EvaluateStrictAnd(list, n, evalFunc)
   end
 
   -- Reuse a scratch token buffer to avoid per-call allocations
   local tokens = _DA_TMP_TOKENS
-  if not tokens then
-    -- Backward-compatible: define on first use if not present in this file yet
-    _DA_TMP_TOKENS = {}
-    tokens = _DA_TMP_TOKENS
-  end
   _DA_WipeArray(tokens)
 
   local i = 1
@@ -411,26 +404,12 @@ function DoiteLogic.EvaluateGeneric(list, evalFunc)
 
   local ok, rpn = pcall(_ToRpn, tokens, _DA_TMP_RPN_OUT, _DA_TMP_OP_STACK)
   if not ok or not rpn then
-    local j = 1
-    while j <= n do
-      if not evalFunc(list[j]) then
-        return false
-      end
-      j = j + 1
-    end
-    return true
+    return _EvaluateStrictAnd(list, n, evalFunc)
   end
 
   local ok2, res = pcall(_EvalRpn, rpn, _DA_TMP_EVAL_STACK)
   if not ok2 then
-    local j = 1
-    while j <= n do
-      if not evalFunc(list[j]) then
-        return false
-      end
-      j = j + 1
-    end
-    return true
+    return _EvaluateStrictAnd(list, n, evalFunc)
   end
 
   return (res == true)

--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -1578,7 +1578,7 @@ function DoiteTrack:_OnSpellCastEvent()
   if selfOnly then
     targetGuid = pGuid
   else
-    if (not targetGuid) or targetGuid == "" or targetGuid == "0x000000000" or targetGuid == "0x0000000000000000" then
+    if _IsBadGuid(targetGuid) then
       local tg = _GetUnitGuidSafe("target")
       if not tg or tg == "" then
         return
@@ -1957,7 +1957,7 @@ function DoiteTrack:_OnAuraNPEvent()
   end
 
   -- Fix invalid/zero targetGuid *after* entry exists.
-  if not targetGuid or targetGuid == "" or targetGuid == "0x000000000" or targetGuid == "0x0000000000000000" then
+  if _IsBadGuid(targetGuid) then
     local selfOnly = false
 
     if event == "AURA_CAST_ON_SELF" then


### PR DESCRIPTION
### Motivation
- Reduce duplicated fallback logic and dead branches in the logic/evaluation code and centralize repeated GUID checks to simplify maintenance and avoid subtle copy-paste errors.

### Description
- Added `_EvaluateStrictAnd(list, n, evalFunc)` to `Modules/DoiteLogic.lua` and replaced repeated strict-AND fallback loops with calls to this helper.
- Allocated the scratch token buffer `_DA_TMP_TOKENS` alongside the other scratch tables and removed the lazy-init dead branch to simplify reuse of the buffer.
- Replaced duplicated inline invalid-GUID checks with the existing helper `_IsBadGuid(targetGuid)` in two places in `Modules/DoiteTrack.lua`.
- These changes are purely refactors intended to preserve existing behavior while removing duplicate/dead code.

### Testing
- Ran a static Python scan that searches for single-reference local functions across `Modules/DoiteGroup.lua`, `Modules/DoiteLogic.lua`, and `Modules/DoiteTrack.lua`, and it reported no single-reference local functions (scan passed).
- Ran pattern checks to confirm `_EvaluateStrictAnd`, `_DA_TMP_TOKENS`, and `_IsBadGuid` usages are present and updated as expected (checks passed).
- `lua`/`luac` parsing/runtime validation could not be executed in this environment and was therefore skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69983f6fd99c832aa0d57367f4e1fa66)