### PR TITLE
Make HasBuffSpellId/HasDebuffSpellId strict spellId checks to fix mine/others duplication

### DIFF
--- a/Modules/DoiteTargetAuras.lua
+++ b/Modules/DoiteTargetAuras.lua
@@ -345,18 +345,10 @@ function DoiteTargetAuras.HasBuffSpellId(spellId)
     end
   end
 
-  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
-  if not spellName then
-    spellName = GetSpellRecField(spellId, "name")
-    if spellName then
-      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
-      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
-    end
-  end
-  if not spellName then
-    return false
-  end
-  return DoiteTargetAuras.HasBuff(spellName)
+  -- IMPORTANT: this API must stay spellId-exact.
+  -- Falling back to HasBuff(name) turns rank/name aliases into false positives,
+  -- which can classify a single aura as both "mine" and "other".
+  return false
 end
 
 function DoiteTargetAuras.HasDebuffSpellId(spellId)
@@ -368,18 +360,8 @@ function DoiteTargetAuras.HasDebuffSpellId(spellId)
     end
   end
 
-  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
-  if not spellName then
-    spellName = GetSpellRecField(spellId, "name")
-    if spellName then
-      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
-      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
-    end
-  end
-  if not spellName then
-    return false
-  end
-  return DoiteTargetAuras.HasDebuff(spellName)
+  -- Keep spellId checks exact for the same reason as HasBuffSpellId.
+  return false
 end
 
 function DoiteTargetAuras.GetHiddenBuffRemaining(spellName)


### PR DESCRIPTION
### Motivation
- Users reported a single aura appearing as both `onlyMine` and `onlyOthers` because rank/name aliasing made non-present spellIds look present via name fallback. 
- The ownership resolution in `DoiteTrack` iterates `entry.spellIds` and relied on `HasBuffSpellId`/`HasDebuffSpellId` to be exact, so the name fallback produced false positives. 
- The intent is to keep ownership classification correct while avoiding broader behavioral changes elsewhere in the addon.

### Description
- Removed the name-based fallback from `DoiteTargetAuras.HasBuffSpellId` so it returns true only for exact `spellId` matches and `false` otherwise. 
- Removed the name-based fallback from `DoiteTargetAuras.HasDebuffSpellId` for the same reason. 
- Added clarifying comments explaining that these APIs must remain `spellId`-exact to avoid rank/name alias false positives.

### Testing
- Performed source inspection of `Modules/DoiteTargetAuras.lua` to verify the removed fallback and the new `false` return in both `Has*SpellId` functions. 
- Searched the codebase with `rg` to confirm there are no lingering `HasBuff(spellName)` / `HasDebuff(spellName)` fallbacks inside the `Has*SpellId` functions. 
- Verified the file diff and function body lines to ensure the change is limited to the two functions and that no other behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699850f260e0832a8213430cf103b211)