### PR TITLE
Separate onlyMine/onlyOthers spell sets for accurate ownership classification

### DIFF
--- a/Modules/DoiteTargetAuras.lua
+++ b/Modules/DoiteTargetAuras.lua
@@ -345,18 +345,10 @@ function DoiteTargetAuras.HasBuffSpellId(spellId)
     end
   end
 
-  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
-  if not spellName then
-    spellName = GetSpellRecField(spellId, "name")
-    if spellName then
-      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
-      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
-    end
-  end
-  if not spellName then
-    return false
-  end
-  return DoiteTargetAuras.HasBuff(spellName)
+  -- IMPORTANT: this API must stay spellId-exact.
+  -- Falling back to HasBuff(name) turns rank/name aliases into false positives,
+  -- which can classify a single aura as both "mine" and "other".
+  return false
 end
 
 function DoiteTargetAuras.HasDebuffSpellId(spellId)
@@ -368,18 +360,8 @@ function DoiteTargetAuras.HasDebuffSpellId(spellId)
     end
   end
 
-  local spellName = DoiteTargetAuras.spellIdToNameCache[spellId]
-  if not spellName then
-    spellName = GetSpellRecField(spellId, "name")
-    if spellName then
-      DoiteTargetAuras.spellIdToNameCache[spellId] = spellName
-      DoiteTargetAuras.spellNameToIdCache[spellName] = spellId
-    end
-  end
-  if not spellName then
-    return false
-  end
-  return DoiteTargetAuras.HasDebuff(spellName)
+  -- Keep spellId checks exact for the same reason as HasBuffSpellId.
+  return false
 end
 
 function DoiteTargetAuras.GetHiddenBuffRemaining(spellName)

--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -305,6 +305,8 @@ local function _AddTrackedFromEntry(_, data)
   if not entry then
     entry = {
       spellIds = {},
+      spellIdsMine = {},
+      spellIdsOthers = {},
       name = name,
       normName = norm,
       kind = data.type,
@@ -314,11 +316,28 @@ local function _AddTrackedFromEntry(_, data)
       onlyMine = false,
       onlyOthers = false,
     }
+  else
+    if type(entry.spellIds) ~= "table" then
+      entry.spellIds = {}
+    end
+    if type(entry.spellIdsMine) ~= "table" then
+      entry.spellIdsMine = {}
+    end
+    if type(entry.spellIdsOthers) ~= "table" then
+      entry.spellIdsOthers = {}
+    end
   end
 
   if sid then
-    entry.spellIds[sid] = true
-    TrackedBySpellId[sid] = entry
+    if isOnlyMine then
+      -- Keep spellIds as the timer-driving set (ours-only behavior).
+      entry.spellIds[sid] = true
+      entry.spellIdsMine[sid] = true
+      TrackedBySpellId[sid] = entry
+    end
+    if isOnlyOthers then
+      entry.spellIdsOthers[sid] = true
+    end
   end
   if norm then
     TrackedByNameNorm[norm] = entry
@@ -2473,6 +2492,30 @@ function DoiteTrack:GetAuraRemainingSecondsByName(spellName, unit)
   return bestRem, bestSpellId
 end
 
+local function _PickOwnershipSpellSet(entry, wantMine)
+  if not entry then
+    return nil
+  end
+
+  if wantMine then
+    if type(entry.spellIdsMine) == "table" then
+      return entry.spellIdsMine
+    end
+    if entry.onlyMine == true then
+      return entry.spellIds
+    end
+    return nil
+  end
+
+  if type(entry.spellIdsOthers) == "table" then
+    return entry.spellIdsOthers
+  end
+  if entry.onlyOthers == true then
+    return entry.spellIds
+  end
+  return nil
+end
+
 function DoiteTrack:RemainingPassesByName(spellName, unit, comp, threshold)
   if not spellName or not unit or not comp or threshold == nil then
     return nil
@@ -2519,22 +2562,39 @@ function DoiteTrack:GetAuraOwnershipByName(spellName, unit)
   local hasOther = false
   local bestRem, bestSpellId = nil, nil
 
+  local mineSpellIds = _PickOwnershipSpellSet(entry, true)
+  local otherSpellIds = _PickOwnershipSpellSet(entry, false)
+
   local sid
-  for sid in pairs(entry.spellIds) do
-    if _AuraHasSpellId(unit, sid, isDebuff) then
-      local rem = _GetRemainingFromState(guid, sid, now)
-      if rem and rem > 0 then
-        hasMine = true
-        if (not bestRem) or rem > bestRem then
-          bestRem = rem
-          bestSpellId = sid
+  if mineSpellIds then
+    for sid in pairs(mineSpellIds) do
+      if _AuraHasSpellId(unit, sid, isDebuff) then
+        local rem = _GetRemainingFromState(guid, sid, now)
+        if rem and rem > 0 then
+          hasMine = true
+          if (not bestRem) or rem > bestRem then
+            bestRem = rem
+            bestSpellId = sid
+          end
         end
       else
-        -- aura present but player have no confirmed timer => treat as "other"
-        hasOther = true
+        _ClearAuraStateForGuidSpell(guid, sid)
       end
-    else
-      _ClearAuraStateForGuidSpell(guid, sid)
+    end
+  end
+
+  if otherSpellIds then
+    for sid in pairs(otherSpellIds) do
+      if _AuraHasSpellId(unit, sid, isDebuff) then
+        local rem = _GetRemainingFromState(guid, sid, now)
+        if not (rem and rem > 0) then
+          -- aura present but player has no confirmed timer => treat as "other"
+          hasOther = true
+          break
+        end
+      else
+        _ClearAuraStateForGuidSpell(guid, sid)
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation
- Previously ownership checks iterated a single merged `spellIds` set which allowed cross-contamination between `onlyMine` and `onlyOthers` configurations and could cause a single aura to be classified as both.
- The intent is to keep timer-driving behavior intact while making ownership classification exact to the configured ownership mode.
- This change isolates mine/other membership so ownership resolution no longer relies on name/rank alias fallbacks or a merged id set.

### Description
- Added `spellIdsMine` and `spellIdsOthers` fields to watchlist entries while preserving `spellIds` as the timer-driving set used by timers and `GetAuraRemainingSecondsByName`.
- Normalized existing/merged entries during `_AddTrackedFromEntry` so `spellIds`, `spellIdsMine`, and `spellIdsOthers` are always tables when present.
- Introduced helper `_PickOwnershipSpellSet(entry, wantMine)` to select the correct id set for ownership checks and updated `DoiteTrack:GetAuraOwnershipByName` to iterate mine and others sets independently.
- Updated insertion logic so `onlyMine` ids populate `spellIds` and `spellIdsMine` (and `TrackedBySpellId`) while `onlyOthers` ids populate `spellIdsOthers` only.

### Testing
- Ran targeted search with `rg -n "spellIdsMine|spellIdsOthers|_PickOwnershipSpellSet|GetAuraOwnershipByName" Modules/DoiteTrack.lua` to verify the new plumbing and it succeeded.
- Verified repository state with `git status --short` and committed the change with `git commit`, which succeeded.
- Attempted to run `luac -p Modules/DoiteTrack.lua` to validate Lua syntax but it failed because `luac` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699850f260e0832a8213430cf103b211)