### PR TITLE
Prevent premature onlyMine fade by preserving tracked mine state on transient aura misses

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -5090,13 +5090,19 @@ local function CheckAuraConditions(data)
       local _, _, _, isMine, isOther, mineKnown = _DoiteTrackAuraOwnership(name, ownerUnit)
 
       if not mineKnown then
-        -- Ownership-gated entries should fail closed when DoiteTrack
-        -- cannot classify the aura owner yet. This prevents both
-        -- "onlyMine" and "onlyOthers" variants from showing together.
-        found = false
+        if ownerFilter == "mine" then
+          -- onlyMine must be confirmed by ownership tracking.
+          found = false
+        elseif ownerFilter == "others" then
+          -- Unknown owner is still "not mine", so allow onlyOthers.
+          -- This also keeps onlyMine/onlyOthers mutually exclusive while
+          -- ownership is unresolved.
+          found = true
+        end
       elseif ownerFilter == "mine" and not isMine then
         found = false
-      elseif ownerFilter == "others" and not isOther then
+      elseif ownerFilter == "others" and ((not isOther) or isMine) then
+        -- If ownership is mixed/ambiguous, prefer onlyMine over onlyOthers.
         found = false
       end
     end

--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -2462,8 +2462,9 @@ function DoiteTrack:GetAuraRemainingSecondsByName(spellName, unit)
         end
       end
     else
-      -- if aura isn't present anymore, clear any stale timer state
-      _ClearAuraStateForGuidSpell(guid, sid)
+      -- Do not clear state here: aura visibility can flicker between scans
+      -- (or coexist with same-name casts by different owners). Let expiry
+      -- logic decide staleness instead of hard-clearing on a single miss.
     end
   end
 
@@ -2534,7 +2535,8 @@ function DoiteTrack:GetAuraOwnershipByName(spellName, unit)
         hasOther = true
       end
     else
-      _ClearAuraStateForGuidSpell(guid, sid)
+      -- Same reasoning as GetAuraRemainingSecondsByName: avoid destructive
+      -- clear on transient miss; preserve mine timer until it truly expires.
     end
   end
 


### PR DESCRIPTION
### Motivation
- Avoid premature hiding of `onlyMine` icons when DoiteTrack briefly misses an aura scan or when a same-name aura by another caster coexists rather than replacing the player's aura. 
- Keep ownership signals raw in `DoiteTrack` and apply display arbitration in `DoiteConditions` so owner policy is localized to the consumer. 
- Ensure `onlyOthers` can still show when ownership is unresolved while `onlyMine` remains strict and requires confirmation.

### Description
- In `Modules/DoiteTrack.lua` removed immediate `_ClearAuraStateForGuidSpell(guid, sid)` calls in `GetAuraRemainingSecondsByName` so tracked player timers are not destroyed on a single transient miss. 
- Applied the same non-destructive behavior in `GetAuraOwnershipByName` and added comments explaining the rationale to preserve mine timers until natural expiry. 
- Kept the earlier `Modules/DoiteConditions.lua` arbitration changes that treat unknown owner as not-mine for `onlyOthers` and require confirmation for `onlyMine`, and ensured ambiguous/mixed ownership prefers `onlyMine` over `onlyOthers`.

### Testing
- Ran targeted source inspections with `rg` and `sed` to locate relevant handlers and verify function contexts, which succeeded. 
- Applied the code edits via a small Python replacement script and validated the resulting diff with `git diff` and `nl | sed` checks, which showed the intended removals and comment additions. 
- Committed the change and confirmed the commit with `git show --oneline --stat HEAD`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6998596436cc832aaa30b77d9fec1ef8)