### PR TITLE
Fix target aura cache refresh during ownership swaps

### DIFF
--- a/Modules/DoiteTargetAuras.lua
+++ b/Modules/DoiteTargetAuras.lua
@@ -456,7 +456,11 @@ BuffAddedOtherFrame:SetScript("OnEvent", function()
   cache.lastSeenTime = GetTime()
 
   if guid == DoiteTargetAuras.targetGuid then
-    SetActiveCache(cache)
+    -- Ownership swaps/refreshes can arrive as compact event sequences where
+    -- slot-level deltas are ambiguous (especially for same-name debuffs).
+    -- Rebuild from the authoritative target aura array to avoid stale
+    -- activeDebuffs/activeBuffs state that can hide icons until a later reset.
+    UpdateAuras()
     NotifyConditionsChanged()
   end
 end)
@@ -500,7 +504,8 @@ BuffRemovedOtherFrame:SetScript("OnEvent", function()
   cache.lastSeenTime = GetTime()
 
   if guid == DoiteTargetAuras.targetGuid then
-    SetActiveCache(cache)
+    -- Keep cache state authoritative during overwrite/replacement sequences.
+    UpdateAuras()
     NotifyConditionsChanged()
   end
 
@@ -542,7 +547,8 @@ DebuffAddedOtherFrame:SetScript("OnEvent", function()
   cache.lastSeenTime = GetTime()
 
   if guid == DoiteTargetAuras.targetGuid then
-    SetActiveCache(cache)
+    -- Keep cache state authoritative during overwrite/replacement sequences.
+    UpdateAuras()
     NotifyConditionsChanged()
   end
 end)
@@ -586,7 +592,8 @@ DebuffRemovedOtherFrame:SetScript("OnEvent", function()
   cache.lastSeenTime = GetTime()
 
   if guid == DoiteTargetAuras.targetGuid then
-    SetActiveCache(cache)
+    -- Keep cache state authoritative during overwrite/replacement sequences.
+    UpdateAuras()
     NotifyConditionsChanged()
   end
 end)


### PR DESCRIPTION
### Motivation
- Rapid ownership swaps of same-name auras could leave `activeBuffs`/`activeDebuffs` in a transient stale state, causing `onlyMine`/`onlyOthers` conditioned icons to flicker or unfiltered icons to disappear when ownership is overtaken.

### Description
- Replace direct `SetActiveCache(cache)` updates with a full `UpdateAuras()` rebuild when `*_OTHER` aura add/remove events affect the current target.
- Apply this change in the `BUFF_ADDED_OTHER`, `BUFF_REMOVED_OTHER`, `DEBUFF_ADDED_OTHER`, and `DEBUFF_REMOVED_OTHER` event handlers inside `Modules/DoiteTargetAuras.lua` so the cache is authoritative and slot mappings are consistent during overwrite/takeover sequences.
- Add comments explaining the rationale to avoid ambiguous slot-level deltas and to preserve stable condition evaluation for owner-filtered and unfiltered icons.

### Testing
- Inspected the produced diff with `git diff -- Modules/DoiteTargetAuras.lua` to verify the four event handlers now call `UpdateAuras()` instead of `SetActiveCache(cache)` and the new comments are present, which succeeded.
- Opened the updated file with `nl -ba Modules/DoiteTargetAuras.lua` to confirm the changes are in the expected locations, which succeeded.
- Attempted a Lua syntax check with `luac -p Modules/DoiteTargetAuras.lua`, but `luac` is not available in this environment so syntax validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699864c2fb60832ab781ee598c87d759)