### PR TITLE
Fallback ownership confirmation for same-rank aura refreshes

### DIFF
--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -2189,6 +2189,41 @@ function DoiteTrack:_OnAuraNPEvent()
           t[targetGuid] = nil
         end
       end
+    else
+      ----------------------------------------------------------------
+      -- Fallback confirm:
+      -- Some exclusive auras (e.g. same-rank HoTs) can be refreshed by player
+      -- without emitting *_ADDED_* events. If player can currently verify the aura
+      -- on a visible unit, treat this cast as confirmed ownership.
+      ----------------------------------------------------------------
+      local probeUnit = nil
+      if targetGuid == pGuid then
+        probeUnit = "player"
+      else
+        local tGuid = _GetUnitGuidSafe("target")
+        if tGuid and tGuid == targetGuid then
+          probeUnit = "target"
+        end
+      end
+
+      if probeUnit and _AuraHasSpellId(probeUnit, spellId, (entry.kind == "Debuff")) then
+        local bucket = _GetAuraBucketForGuid(targetGuid, true)
+        if bucket then
+          local a = bucket[spellId]
+          if not a then
+            a = {}
+            bucket[spellId] = a
+          end
+
+          a.appliedAt = now
+          a.lastSeen = now
+          a.fullDur = secRounded
+          a.cp = cp or 0
+          a.isDebuff = (entry.kind == "Debuff")
+
+          t[targetGuid] = nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation
- Equal-rank exclusive auras (e.g. Rejuvenation rank refreshes) can be reapplied without emitting the usual `*_ADDED_*` confirm events, leaving ownership attributed to the other caster and preventing `onlyMine` icons from flipping.
- The tracker must conservatively detect when a player-cast actually refreshed a visible aura so runtime ownership/timers move to the player.

### Description
- Added a fallback confirmation branch inside `DoiteTrack:_OnAuraNPEvent` that runs when `AURA_CAST` reported a positive duration but no `*_ADDED_*` confirm arrived, and `p.confirmAt` was not set.
- The fallback probes a visible unit (`"player"` when target GUID == player GUID, or `"target"` when the current target matches the target GUID) and uses `_AuraHasSpellId` to verify the aura presence before claiming ownership.
- When verification succeeds the code updates the runtime state in `AuraStateByGuid[targetGuid]` (`appliedAt`, `lastSeen`, `fullDur`, `cp`, `isDebuff`) and clears the pending entry so `onlyMine`/`onlyOthers` logic reflects the refreshed ownership.

### Testing
- Attempted syntactic check with `luac -p Modules/DoiteTrack.lua`, but `luac` was not available in this environment (failure).
- Inspected the diff with `git diff -- Modules/DoiteTrack.lua` and verified the new fallback block was inserted and scoped to visible-unit verification (success).
- Committed the change with `git commit` (success) and created the PR with the provided summary (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69986c7d3b84832a9cfa7f3b1f9b606d)