### PR TITLE
Fix debuff overflow detection for target aura ownership

### DIFF
--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -506,8 +506,10 @@ local function _AuraHasSpellId(unit, spellId, isDebuff)
     end
   end
 
-  -- debuff overflow: sometimes debuffs spill into buff field when 16-cap is hit
-  if isDebuff and n and n >= 16 then
+  -- debuff overflow: overflow debuffs can remain in buff-facing fields even when
+  -- the visible debuff list drops below 16 (slots do not backfill/reclassify).
+  -- Always probe buff-facing fields for spellId-exact presence when querying a debuff.
+  if isDebuff then
     local buffs = _GetUnitAuraTable(unit, false)
     if type(buffs) == "table" then
       if buffs[spellId] then


### PR DESCRIPTION
### Motivation
- Prevent false-negative debuff presence detections when overflow debuffs live in buff-facing slots due to the client/server behavior where aura slots do not backfill/reclassify, so ownership/timer logic that depends on precise presence checks (`onlyMine`/`onlyOthers`) remains correct.

### Description
- Updated `_AuraHasSpellId` in `Modules/DoiteTrack.lua` to always probe buff-facing aura tables when `isDebuff` is true, removing the previous `n >= 16` gate so spellId-exact overflow debuffs are not missed.

### Testing
- Performed repository inspections and sanity checks including `git diff`, `nl -ba` views of `Modules/DoiteTrack.lua`, `Modules/DoiteTargetAuras.lua`, and `Modules/DoiteConditions.lua`, and committed the change; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999c66c8030832a953b2a877f8107c0)