### PR TITLE
Fix target aura refresh for player targets

### DIFF
--- a/Modules/DoiteTargetAuras.lua
+++ b/Modules/DoiteTargetAuras.lua
@@ -202,8 +202,9 @@ local function IsCurrentTargetPlayer()
     return false
   end
 
-  local _, playerGuid = UnitExists("player")
-  return playerGuid and DoiteTargetAuras.targetGuid == playerGuid
+  -- We need this for any player target (self or other players), because
+  -- *_OTHER aura delta events are unreliable for player units.
+  return UnitIsPlayer("target") and true or false
 end
 
 local function UpdateAuras()


### PR DESCRIPTION
### Motivation
- Debuff icons were only reliably appearing for NPC targets because the addon only treated the current target as "player" when its GUID matched the player's GUID, preventing the player-target fallback refresh for other players.

### Description
- Replace GUID-equality check in `IsCurrentTargetPlayer()` with `UnitIsPlayer("target")` so the fallback self-aura/UNIT_AURA refresh path runs for any player target (self or other players). 

### Testing
- Verified the change by inspecting the modified `Modules/DoiteTargetAuras.lua` and confirming `UnitIsPlayer("target")` is present in `IsCurrentTargetPlayer()`; the verification succeeded.
- Performed a code diff review of the file to ensure only the intended lines were changed; the review succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d8e197dd4832a882e23e7a8a401d4)