### PR TITLE
Reduce top-level local usage in DoiteConditions.lua

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -34,7 +34,6 @@ local GetComboPoints = GetComboPoints
 local GetNumTalentTabs = GetNumTalentTabs
 local GetNumTalents = GetNumTalents
 local GetTalentInfo = GetTalentInfo
-local _GetTime = GetTime
 local _GetAuraStacksOnUnit
 local _StacksPasses
 local str_find = string.find
@@ -151,7 +150,7 @@ end
 
 local function _Now()
 
-  return (_GetTime and _GetTime()) or 0
+  return (GetTime and GetTime()) or 0
 end
 
 -- Spell index cache (must be defined before any usage)
@@ -7427,7 +7426,7 @@ function DoiteConditions_OnUpdate(dt)
     local hasTE = false
 
     if te then
-      local now = _GetTime()
+      local now = GetTime()
       for _, slotC in pairs(te) do
         if slotC and slotC.endTime then
           local rem = slotC.endTime - now


### PR DESCRIPTION
### Motivation
- Prevent hitting Lua's chunk-level local-variable limit by reducing the number of top-level `local` declarations in `Modules/DoiteConditions.lua`.

### Description
- Removed the redundant alias `local _GetTime = GetTime` and updated callers to invoke `GetTime()` directly (used in `_Now()` and the temp-enchant OnUpdate path) with no functional change.

### Testing
- Ran `rg -n '^local ' Modules/DoiteConditions.lua | wc -l` which returned `200`, confirming the top-level local count dropped; `rg -n '\b_GetTime\b' Modules/DoiteConditions.lua` returned no remaining references; `git diff -- Modules/DoiteConditions.lua` showed only the intended substitutions, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a047569ec0832aad7496cfe88dc821)