### PR TITLE
Add spell-id (Addedviaspellid) support for aura checks, stacks and tracking

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2463,12 +2463,22 @@ local function _GetBaseXY(key, dataTbl)
 end
 
 -- Player-only aura remaining (seconds); nil if not timed / not found.
-local function _PlayerAuraRemainingSeconds(auraName)
-  if not auraName then
-    return nil
+local function _PlayerAuraRemainingSeconds(auraName, auraSpellId, addedViaSpellId)
+  local useSpellIdOnly = (addedViaSpellId == true)
+  local playerAuraSlot = nil
+
+  if useSpellIdOnly then
+    local sid = tonumber(auraSpellId) or 0
+    if sid > 0 then
+      playerAuraSlot = DoitePlayerAuras.GetActiveAuraSlotBySpellId(sid)
+    end
+  else
+    if not auraName then
+      return nil
+    end
+    playerAuraSlot = DoitePlayerAuras.GetActiveAuraSlot(auraName)
   end
 
-  local playerAuraSlot = DoitePlayerAuras.GetActiveAuraSlot(auraName)
   if playerAuraSlot then
     local _, remainingMs, _ = GetPlayerAuraDuration(playerAuraSlot)
     if remainingMs and remainingMs > 0 then
@@ -2476,26 +2486,35 @@ local function _PlayerAuraRemainingSeconds(auraName)
     end
   end
 
-  -- get remaining for buff cap spells
-  local remaining = DoitePlayerAuras.GetHiddenBuffRemaining(auraName)
-  if remaining and remaining > 0 then
-    return remaining
+  if not useSpellIdOnly then
+    local remaining = DoitePlayerAuras.GetHiddenBuffRemaining(auraName)
+    if remaining and remaining > 0 then
+      return remaining
+    end
   end
 
   return nil
 end
 
-local function _DoiteTrackAuraOwnership(spellName, unit)
-  if not DoiteTrack or not spellName or not unit then
+local function _DoiteTrackAuraOwnership(spellKey, unit, useSpellId)
+  if not DoiteTrack or not spellKey or not unit then
     return nil, false, nil, false, false, false
   end
 
   -- Hard dependency on the consolidated helper
-  if not DoiteTrack.GetAuraOwnershipByName then
-    return nil, false, nil, false, false, false
-  end
+  local rem, recording, sid, isMine, isOther, ownerKnown
 
-  local rem, recording, sid, isMine, isOther, ownerKnown = DoiteTrack:GetAuraOwnershipByName(spellName, unit)
+  if useSpellId == true then
+    if not DoiteTrack.GetAuraOwnershipBySpellId then
+      return nil, false, nil, false, false, false
+    end
+    rem, recording, sid, isMine, isOther, ownerKnown = DoiteTrack:GetAuraOwnershipBySpellId(spellKey, unit)
+  else
+    if not DoiteTrack.GetAuraOwnershipByName then
+      return nil, false, nil, false, false, false
+    end
+    rem, recording, sid, isMine, isOther, ownerKnown = DoiteTrack:GetAuraOwnershipByName(spellKey, unit)
+  end
 
   -- Normalize booleans
   isMine = (isMine == true)
@@ -2518,20 +2537,25 @@ local function _DoiteTrackAuraOwnership(spellName, unit)
 end
 
 -- Unified remaining-time provider used by existing call sites (DoiteTrack only).
-local function _DoiteTrackAuraRemainingSeconds(spellName, unit)
-  if not DoiteTrack or not spellName or not unit then
+local function _DoiteTrackAuraRemainingSeconds(spellKey, unit, useSpellId)
+  if not DoiteTrack or not spellKey or not unit then
     return nil
   end
 
-  if DoiteTrack.GetAuraRemainingSecondsByName then
-    local rem = DoiteTrack:GetAuraRemainingSecondsByName(spellName, unit)
+  if useSpellId == true and DoiteTrack.GetAuraRemainingSecondsBySpellId then
+    local rem = DoiteTrack:GetAuraRemainingSecondsBySpellId(spellKey, unit)
+    if rem and rem > 0 then
+      return rem
+    end
+  elseif DoiteTrack.GetAuraRemainingSecondsByName then
+    local rem = DoiteTrack:GetAuraRemainingSecondsByName(spellKey, unit)
     if rem and rem > 0 then
       return rem
     end
   end
 
   if DoiteTrack.GetAuraRemainingOrRecordingByName then
-    local rem2 = DoiteTrack:GetAuraRemainingOrRecordingByName(spellName, unit)
+    local rem2 = DoiteTrack:GetAuraRemainingOrRecordingByName(spellKey, unit)
     if rem2 and rem2 > 0 then
       return rem2
     end
@@ -2542,18 +2566,20 @@ end
 
 
 -- Use DoiteTrack to evaluate a remaining-time comparison on a unit.
-local function _DoiteTrackRemainingPass(spellName, unit, comp, threshold)
-  if not DoiteTrack or not spellName or not unit or not comp or threshold == nil then
+local function _DoiteTrackRemainingPass(spellKey, unit, comp, threshold, useSpellId)
+  if not DoiteTrack or not spellKey or not unit or not comp or threshold == nil then
     return nil
   end
 
-  if DoiteTrack.RemainingPassesByName then
+  if useSpellId == true and DoiteTrack.RemainingPassesBySpellId then
+    return DoiteTrack:RemainingPassesBySpellId(spellKey, unit, comp, threshold)
+  elseif DoiteTrack.RemainingPassesByName then
     -- Add-on helper handles comparison internally
-    return DoiteTrack:RemainingPassesByName(spellName, unit, comp, threshold)
+    return DoiteTrack:RemainingPassesByName(spellKey, unit, comp, threshold)
   end
 
   -- Fallback within DoiteTrack: if no helper, compare using numeric remaining
-  local rem = _DoiteTrackAuraRemainingSeconds(spellName, unit)
+  local rem = _DoiteTrackAuraRemainingSeconds(spellKey, unit, useSpellId)
   if rem and rem > 0 then
     return _RemainingPasses(rem, comp, threshold)
   end
@@ -2610,6 +2636,39 @@ local function _TargetHasAura(auraName, wantDebuff)
     local b = snap.buffs
     return b and b[auraName] == true
   end
+end
+
+
+local function _TargetHasAuraBySpellId(spellId, wantDebuff)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return false
+  end
+
+  local snap = auraSnapshot["target"]
+  if not snap then
+    return false
+  end
+
+  if wantDebuff then
+    local d = snap.debuffIds
+    if d and d[spellId] then
+      return true
+    end
+
+    local count = snap.debuffCount or 0
+    if count >= 16 then
+      local b = snap.buffIds
+      if b and b[spellId] then
+        return true
+      end
+    end
+
+    return false
+  end
+
+  local b = snap.buffIds
+  return b and b[spellId] == true
 end
 
 -- Talent helpers for auraConditions (Known / Not known)
@@ -2809,23 +2868,37 @@ local function _AuraConditions_CheckEntry(entry)
   -- Has aura?
   ----------------------------------------------------------------
   local hasAura = false
+  local useSpellIdOnly = (entry.Addedviaspellid == true)
+  local auraSpellId = tonumber(entry.spellid) or 0
 
   if unit == "player" then
-    if (not wantDebuff) and DoitePlayerAuras.HasBuff(name) then
-      hasAura = true
-    elseif wantDebuff and DoitePlayerAuras.HasDebuff(name) then
-      hasAura = true
+    if useSpellIdOnly and auraSpellId > 0 then
+      if (not wantDebuff) and DoitePlayerAuras.HasBuffSpellId(auraSpellId) then
+        hasAura = true
+      elseif wantDebuff and DoitePlayerAuras.HasDebuffSpellId(auraSpellId) then
+        hasAura = true
+      end
+    else
+      if (not wantDebuff) and DoitePlayerAuras.HasBuff(name) then
+        hasAura = true
+      elseif wantDebuff and DoitePlayerAuras.HasDebuff(name) then
+        hasAura = true
+      end
     end
   else
     -- unit == "target"
-    hasAura = _TargetHasAura(name, wantDebuff)
+    if useSpellIdOnly and auraSpellId > 0 then
+      hasAura = _TargetHasAuraBySpellId(auraSpellId, wantDebuff)
+    else
+      hasAura = _TargetHasAura(name, wantDebuff)
+    end
   end
 
   ----------------------------------------------------------------
   -- If stacks enabled and aura exists, compute stacks and compare.
   ----------------------------------------------------------------
   if stacksEnabled and hasAura then
-    local cnt = _GetAuraStacksOnUnit(unit, name, wantDebuff)
+    local cnt = _GetAuraStacksOnUnit(unit, name, wantDebuff, auraSpellId, useSpellIdOnly)
     if cnt == nil then
       cnt = 1
     end
@@ -2901,13 +2974,25 @@ _StacksPasses = function(cnt, comp, target)
 end
 
 -- Get stack count for a named aura on target (or player). Uses DoitePlayerAuras for player checks.
-_GetAuraStacksOnUnit = function(unit, auraName, wantDebuff)
+_GetAuraStacksOnUnit = function(unit, auraName, wantDebuff, auraSpellId, addedViaSpellId)
   if not unit or not auraName then
     return nil
   end
 
   -- Use DoitePlayerAuras for player checks
   if unit == "player" then
+    if addedViaSpellId == true then
+      local sid = tonumber(auraSpellId) or 0
+      if sid <= 0 then
+        return nil
+      end
+      if wantDebuff then
+        return DoitePlayerAuras.GetDebuffStacksBySpellId(sid)
+      else
+        return DoitePlayerAuras.GetBuffStacksBySpellId(sid)
+      end
+    end
+
     if wantDebuff then
       return DoitePlayerAuras.GetDebuffStacks(auraName)
     else
@@ -2938,7 +3023,11 @@ _GetAuraStacksOnUnit = function(unit, auraName, wantDebuff)
       name = _NP_SpellNameAndTexture(auraId)
     end
 
-    if name == auraName then
+    if addedViaSpellId == true then
+      if auraId and auraSpellId and tonumber(auraId) == tonumber(auraSpellId) then
+        return applications or 1
+      end
+    elseif name == auraName then
       return applications or 1
     end
 
@@ -5466,7 +5555,15 @@ local function CheckAuraConditions(data)
   end
 
   local name = data.displayName or data.name
-  if not name then
+  local useSpellIdOnly = (data.Addedviaspellid == true)
+  local auraSpellId = tonumber(data.spellid) or 0
+
+  if useSpellIdOnly and auraSpellId <= 0 then
+    data._daSoundGate = false
+    return false, false, false
+  end
+
+  if (not useSpellIdOnly) and (not name) then
     data._daSoundGate = false
     return false, false, false
   end
@@ -5530,11 +5627,20 @@ local function CheckAuraConditions(data)
 
   if show and allowSelf then
     local hit = false
-    if wantBuff then
-      hit = DoitePlayerAuras.HasBuff(name)
-    end
-    if (not hit) and wantDebuff then
-      hit = DoitePlayerAuras.HasDebuff(name)
+    if useSpellIdOnly and auraSpellId > 0 then
+      if wantBuff then
+        hit = DoitePlayerAuras.HasBuffSpellId(auraSpellId)
+      end
+      if (not hit) and wantDebuff then
+        hit = DoitePlayerAuras.HasDebuffSpellId(auraSpellId)
+      end
+    else
+      if wantBuff then
+        hit = DoitePlayerAuras.HasBuff(name)
+      end
+      if (not hit) and wantDebuff then
+        hit = DoitePlayerAuras.HasDebuff(name)
+      end
     end
     if hit then
       found = true
@@ -5545,10 +5651,18 @@ local function CheckAuraConditions(data)
     local s = auraSnapshot.target
     if s then
       local hit = false
-      if wantBuff and s.buffs[name] then
-        hit = true
-      elseif wantDebuff and _TargetHasOverflowDebuff(name) then
-        hit = true
+      if useSpellIdOnly and auraSpellId > 0 then
+        if wantBuff and s.buffIds and s.buffIds[auraSpellId] then
+          hit = true
+        elseif wantDebuff and _TargetHasAuraBySpellId(auraSpellId, true) then
+          hit = true
+        end
+      else
+        if wantBuff and s.buffs[name] then
+          hit = true
+        elseif wantDebuff and _TargetHasOverflowDebuff(name) then
+          hit = true
+        end
       end
       if hit then
         found = true
@@ -5560,10 +5674,18 @@ local function CheckAuraConditions(data)
     local s = auraSnapshot.target
     if s then
       local hit = false
-      if wantBuff and s.buffs[name] then
-        hit = true
-      elseif wantDebuff and _TargetHasOverflowDebuff(name) then
-        hit = true
+      if useSpellIdOnly and auraSpellId > 0 then
+        if wantBuff and s.buffIds and s.buffIds[auraSpellId] then
+          hit = true
+        elseif wantDebuff and _TargetHasAuraBySpellId(auraSpellId, true) then
+          hit = true
+        end
+      else
+        if wantBuff and s.buffs[name] then
+          hit = true
+        elseif wantDebuff and _TargetHasOverflowDebuff(name) then
+          hit = true
+        end
       end
       if hit then
         found = true
@@ -5579,7 +5701,7 @@ local function CheckAuraConditions(data)
       ownerUnit = "target"
     end
     if ownerUnit then
-      local _, _, _, isMine, isOther, mineKnown = _DoiteTrackAuraOwnership(name, ownerUnit)
+      local _, _, _, isMine, isOther, mineKnown = _DoiteTrackAuraOwnership(useSpellIdOnly and auraSpellId or name, ownerUnit, useSpellIdOnly)
       if mineKnown then
         if ownerFilter == "mine" and not isMine then
           found = false
@@ -5725,7 +5847,7 @@ local function CheckAuraConditions(data)
         local comp = c.remainingComp
         local pass = true
         if targetSelf then
-          local rem = _PlayerAuraRemainingSeconds(name)
+          local rem = _PlayerAuraRemainingSeconds(name, auraSpellId, useSpellIdOnly)
           if rem and rem > 0 then
             pass = _RemainingPasses(rem, comp, threshold)
           else
@@ -5733,7 +5855,7 @@ local function CheckAuraConditions(data)
           end
         else
           if ownerFilter == "mine" and DoiteTrack then
-            local rpass = _DoiteTrackRemainingPass(name, "target", comp, threshold)
+            local rpass = _DoiteTrackRemainingPass(useSpellIdOnly and auraSpellId or name, "target", comp, threshold, useSpellIdOnly)
             if rpass == nil then
               pass = false
             else
@@ -5770,7 +5892,7 @@ local function CheckAuraConditions(data)
         end
       end
       if unitToCheck then
-        local cnt = _GetAuraStacksOnUnit(unitToCheck, name, wantDebuff)
+        local cnt = _GetAuraStacksOnUnit(unitToCheck, name, wantDebuff, auraSpellId, useSpellIdOnly)
         if cnt and (not _StacksPasses(cnt, c.stacksComp, threshold)) then
           show = false
         end
@@ -6150,6 +6272,8 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
 
       if ca.textTimeRemaining == true then
         local auraName = dataTbl.displayName or dataTbl.name
+      local useSpellIdOnly = (dataTbl.Addedviaspellid == true)
+      local auraSpellId = tonumber(dataTbl.spellid) or 0
 
         local allowHelp = (ca.targetHelp == true)
         local allowHarm = (ca.targetHarm == true)
@@ -6177,10 +6301,10 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
 
         if targetSelf then
           -- PLAYER/SELF remaining-time text must reflect the actual visible aura time (vanilla/tooltip scan), never DoiteTrack. Ownership filtering (onlyMine/onlyOthers) belongs in the condition logic.
-          remAura = _PlayerAuraRemainingSeconds(auraName)
+          remAura = _PlayerAuraRemainingSeconds(auraName, auraSpellId, useSpellIdOnly)
         else
           -- Target remaining time relies on DoiteTrack (vanilla target auras don't expose durations).
-          remAura = _DoiteTrackAuraRemainingSeconds(auraName, "target")
+          remAura = _DoiteTrackAuraRemainingSeconds(useSpellIdOnly and auraSpellId or auraName, "target", useSpellIdOnly)
         end
 
         if remAura and remAura > 0 then
@@ -6221,6 +6345,8 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
     local ca = dataTbl.conditions.aura
     if ca.textStackCounter == true then
       local auraName = dataTbl.displayName or dataTbl.name
+      local useSpellIdOnly = (dataTbl.Addedviaspellid == true)
+      local auraSpellId = tonumber(dataTbl.spellid) or 0
       local wantDebuff = (dataTbl.type == "Debuff")
 
       -- Resolve which unit to read stacks from (same semantics as CheckAuraConditions)
@@ -6251,7 +6377,7 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
       end
 
       if unitToCheck then
-        local cnt = _GetAuraStacksOnUnit(unitToCheck, auraName, wantDebuff)
+        local cnt = _GetAuraStacksOnUnit(unitToCheck, auraName, wantDebuff, auraSpellId, useSpellIdOnly)
         if cnt and cnt >= 1 then
           local s = _DA_NumToStr(cnt)
           if s ~= frame._daLastStacksText then

--- a/Modules/DoitePlayerAuras.lua
+++ b/Modules/DoitePlayerAuras.lua
@@ -17,6 +17,8 @@ local DoitePlayerAuras = {
 
   activeBuffs = {}, -- spell name -> slot
   activeDebuffs = {}, -- spell name -> slot
+  activeBuffSpellIds = {}, -- spellId -> slot
+  activeDebuffSpellIds = {}, -- spellId -> slot
 
   cappedBuffsExpirationTime = {}, -- spell name -> expiration time in seconds
   cappedBuffsStacks = {}, -- spell name -> stacks
@@ -48,6 +50,12 @@ end
 _G["DoitePlayerAuras"] = DoitePlayerAuras
 
 local function MarkActive(spellId, activeTable, slot)
+  if activeTable == DoitePlayerAuras.activeBuffs then
+    DoitePlayerAuras.activeBuffSpellIds[spellId] = slot
+  elseif activeTable == DoitePlayerAuras.activeDebuffs then
+    DoitePlayerAuras.activeDebuffSpellIds[spellId] = slot
+  end
+
   -- cache spell name if not already cached
   if not DoitePlayerAuras.spellIdToNameCache[spellId] then
     local spellName = GetSpellRecField(spellId, "name")
@@ -66,6 +74,12 @@ local function MarkActive(spellId, activeTable, slot)
 end
 
 local function MarkInactive(spellId, activeTable)
+  if activeTable == DoitePlayerAuras.activeBuffs then
+    DoitePlayerAuras.activeBuffSpellIds[spellId] = false
+  elseif activeTable == DoitePlayerAuras.activeDebuffs then
+    DoitePlayerAuras.activeDebuffSpellIds[spellId] = false
+  end
+
   local spellName = DoitePlayerAuras.spellIdToNameCache[spellId]
   if spellName then
     activeTable[spellName] = false
@@ -86,6 +100,8 @@ local function UpdateAuras()
   -- clear active buffs/debuffs
   DoitePlayerAuras.activeBuffs = {}
   DoitePlayerAuras.activeDebuffs = {}
+  DoitePlayerAuras.activeBuffSpellIds = {}
+  DoitePlayerAuras.activeDebuffSpellIds = {}
 
   -- aura array becomes 1-indexed in Lua: 1-32 are buffs, 33-48 are debuffs
   DoitePlayerAuras.numActiveBuffs = 0
@@ -142,9 +158,25 @@ function DoitePlayerAuras.HasBuff(spellName)
       DoitePlayerAuras.IsHiddenByBuffCap(spellName)
 end
 
+function DoitePlayerAuras.HasBuffSpellId(spellId)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return false
+  end
+  return DoitePlayerAuras.activeBuffSpellIds[spellId] or false
+end
+
 function DoitePlayerAuras.HasDebuff(spellName)
   -- don't think it's possible to hit debuff cap as a player currently, not gonna worry about it
   return DoitePlayerAuras.activeDebuffs[spellName] or false
+end
+
+function DoitePlayerAuras.HasDebuffSpellId(spellId)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return false
+  end
+  return DoitePlayerAuras.activeDebuffSpellIds[spellId] or false
 end
 
 function DoitePlayerAuras.GetActiveAuraSlot(spellName)
@@ -154,6 +186,25 @@ function DoitePlayerAuras.GetActiveAuraSlot(spellName)
   end
 
   local debuffSlot = DoitePlayerAuras.activeDebuffs[spellName]
+  if debuffSlot then
+    return MAX_BUFF_SLOTS + debuffSlot - 1 -- 32-47
+  end
+
+  return nil
+end
+
+function DoitePlayerAuras.GetActiveAuraSlotBySpellId(spellId)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return nil
+  end
+
+  local buffSlot = DoitePlayerAuras.activeBuffSpellIds[spellId]
+  if buffSlot then
+    return buffSlot - 1 -- 0-31
+  end
+
+  local debuffSlot = DoitePlayerAuras.activeDebuffSpellIds[spellId]
   if debuffSlot then
     return MAX_BUFF_SLOTS + debuffSlot - 1 -- 32-47
   end
@@ -197,6 +248,29 @@ function DoitePlayerAuras.GetBuffStacks(spellName)
   return nil
 end
 
+function DoitePlayerAuras.GetBuffStacksBySpellId(spellId)
+  local cachedSlot = DoitePlayerAuras.HasBuffSpellId(spellId)
+  if not cachedSlot then
+    return nil
+  end
+
+  if DoitePlayerAuras.buffs[cachedSlot] and DoitePlayerAuras.buffs[cachedSlot].spellId == spellId then
+    return DoitePlayerAuras.buffs[cachedSlot].stacks
+  end
+
+  for i = 1, MAX_BUFF_SLOTS do
+    if not DoitePlayerAuras.buffs[i].spellId then
+      break
+    end
+
+    if DoitePlayerAuras.buffs[i].spellId == spellId then
+      return DoitePlayerAuras.buffs[i].stacks
+    end
+  end
+
+  return nil
+end
+
 function DoitePlayerAuras.GetDebuffStacks(spellName)
   -- check if active and get cached slot
   local cachedSlot = DoitePlayerAuras.activeDebuffs[spellName]
@@ -215,6 +289,29 @@ function DoitePlayerAuras.GetDebuffStacks(spellName)
   end
 
   -- fallback: search through debuffs for matching spell ID
+  for i = 1, MAX_DEBUFF_SLOTS do
+    if not DoitePlayerAuras.debuffs[i].spellId then
+      break
+    end
+
+    if DoitePlayerAuras.debuffs[i].spellId == spellId then
+      return DoitePlayerAuras.debuffs[i].stacks
+    end
+  end
+
+  return nil
+end
+
+function DoitePlayerAuras.GetDebuffStacksBySpellId(spellId)
+  local cachedSlot = DoitePlayerAuras.HasDebuffSpellId(spellId)
+  if not cachedSlot then
+    return nil
+  end
+
+  if DoitePlayerAuras.debuffs[cachedSlot] and DoitePlayerAuras.debuffs[cachedSlot].spellId == spellId then
+    return DoitePlayerAuras.debuffs[cachedSlot].stacks
+  end
+
   for i = 1, MAX_DEBUFF_SLOTS do
     if not DoitePlayerAuras.debuffs[i].spellId then
       break

--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -287,8 +287,13 @@ local function _AddTrackedFromEntry(_, data)
     sid = nil
   end
 
+  local addedViaSpellId = (data.Addedviaspellid == true)
   local name = data.displayName or data.name or ""
   local norm = _NormSpellName(name)
+
+  if addedViaSpellId then
+    norm = nil
+  end
 
   if not sid and not norm then
     return
@@ -313,7 +318,10 @@ local function _AddTrackedFromEntry(_, data)
       trackHarm = false,
       onlyMine = false,
       onlyOthers = false,
+      addedViaSpellId = addedViaSpellId,
     }
+  elseif addedViaSpellId then
+    entry.addedViaSpellId = true
   end
 
   if sid then
@@ -1926,32 +1934,40 @@ function DoiteTrack:_OnAuraNPEvent()
 
   -- Resolve tracked entry (spellId first, then name)
   local entry = TrackedBySpellId[spellId]
-  if (not entry) and spellNameNorm then
-    local byN = TrackedByNameNorm[spellNameNorm]
-    if byN and byN.onlyMine == true then
-      entry = byN
-      entry.spellIds = entry.spellIds or {}
-      if not entry.spellIds[spellId] then
-        entry.spellIds[spellId] = true
-      end
-      TrackedBySpellId[spellId] = entry
+  local byN = nil
+  if spellNameNorm then
+    byN = TrackedByNameNorm[spellNameNorm]
+  end
 
-      -- Keep Flame Shock rank list cache in sync when player discover a new rank by name.
-      if _IsPlayerShaman and spellNameNorm == "flame shock" and entry.kind == "Debuff" then
-        if type(_FlameShockSpellIdsList) ~= "table" then
-          _FlameShockSpellIdsList = {}
+  -- Always seed name-tracked onlyMine entries with discovered spellId, even when a strict
+  -- Addedviaspellid entry already occupies TrackedBySpellId[spellId].
+  -- This keeps ownership/remaining logic correct for name-tracked icons in mixed setups.
+  if byN and byN.onlyMine == true then
+    byN.spellIds = byN.spellIds or {}
+    if not byN.spellIds[spellId] then
+      byN.spellIds[spellId] = true
+    end
+
+    if not entry then
+      entry = byN
+      TrackedBySpellId[spellId] = entry
+    end
+
+    -- Keep Flame Shock rank list cache in sync when player discover a new rank by name.
+    if _IsPlayerShaman and spellNameNorm == "flame shock" and byN.kind == "Debuff" then
+      if type(_FlameShockSpellIdsList) ~= "table" then
+        _FlameShockSpellIdsList = {}
+      end
+      local i = 1
+      while _FlameShockSpellIdsList[i] do
+        if _FlameShockSpellIdsList[i] == spellId then
+          i = nil
+          break
         end
-        local i = 1
-        while _FlameShockSpellIdsList[i] do
-          if _FlameShockSpellIdsList[i] == spellId then
-            i = nil
-            break
-          end
-          i = i + 1
-        end
-        if i then
-          _FlameShockSpellIdsList[i] = spellId
-        end
+        i = i + 1
+      end
+      if i then
+        _FlameShockSpellIdsList[i] = spellId
       end
     end
   end
@@ -2116,6 +2132,32 @@ function DoiteTrack:_OnAuraNPEvent()
             t[targetGuid] = nil
             return
           end
+        end
+      end
+    end
+
+    -- If cast target is our current target and aura presence is immediately verifiable,
+    -- arm now as well. This handles "take over" refreshes that may not fire *_ADDED_*.
+    do
+      local tg = _GetUnitGuidSafe("target")
+      local isDeb = (entry.kind == "Debuff")
+      if tg and tg == targetGuid and _AuraHasSpellId("target", spellId, isDeb) then
+        local bucket = _GetAuraBucketForGuid(targetGuid, true)
+        if bucket then
+          local a = bucket[spellId]
+          if not a then
+            a = {}
+            bucket[spellId] = a
+          end
+
+          a.appliedAt = now
+          a.fullDur = secRounded
+          a.cp = cp or 0
+          a.isDebuff = isDeb
+          a.lastSeen = now
+
+          t[targetGuid] = nil
+          return
         end
       end
     end
@@ -2377,6 +2419,57 @@ local function _GetEntryForName(spellName)
   return TrackedByNameNorm[norm]
 end
 
+local function _AuraHasNormName(unit, wantNormName, isDebuff)
+  if not unit or not wantNormName then
+    return false
+  end
+
+  local auras = _GetUnitAuraTable(unit, isDebuff)
+  if type(auras) ~= "table" then
+    return false
+  end
+
+  local n = table.getn(auras)
+  if not n or n <= 0 then
+    return false
+  end
+
+  local i
+  for i = 1, n do
+    local sid = tonumber(auras[i]) or 0
+    if sid > 0 then
+      local n0 = _GetSpellNameRank(sid)
+      local nn = _NormSpellName(n0)
+      if nn and nn == wantNormName then
+        return true
+      end
+    end
+  end
+
+  -- Debuff-overflow safety: when debuff table is full-ish, also inspect buffs.
+  if isDebuff and n >= 16 then
+    local buffs = _GetUnitAuraTable(unit, false)
+    if type(buffs) == "table" then
+      local n2 = table.getn(buffs)
+      if n2 and n2 > 0 then
+        local j
+        for j = 1, n2 do
+          local sid2 = tonumber(buffs[j]) or 0
+          if sid2 > 0 then
+            local n1 = _GetSpellNameRank(sid2)
+            local nn2 = _NormSpellName(n1)
+            if nn2 and nn2 == wantNormName then
+              return true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return false
+end
+
 function DoiteTrack:GetAuraRemainingSecondsByName(spellName, unit)
   if not spellName or not unit then
     return nil
@@ -2423,12 +2516,69 @@ function DoiteTrack:GetAuraRemainingSecondsByName(spellName, unit)
   return bestRem, bestSpellId
 end
 
+function DoiteTrack:GetAuraRemainingSecondsBySpellId(spellId, unit)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 or not unit then
+    return nil
+  end
+
+  local entry = TrackedBySpellId[spellId]
+  if not entry then
+    return nil
+  end
+
+  if not _UnitExistsFlag(unit) then
+    return nil
+  end
+
+  local guid = _GetUnitGuidSafe(unit)
+  if not guid then
+    return nil
+  end
+
+  local isDebuff = (entry.kind == "Debuff")
+  if not _AuraHasSpellId(unit, spellId, isDebuff) then
+    _ClearAuraStateForGuidSpell(guid, spellId)
+    return nil
+  end
+
+  local now = GetTime and GetTime() or 0
+  local rem = _GetRemainingFromState(guid, spellId, now)
+  if rem and rem > 0 then
+    return rem, spellId
+  end
+
+  return nil
+end
+
 function DoiteTrack:RemainingPassesByName(spellName, unit, comp, threshold)
   if not spellName or not unit or not comp or threshold == nil then
     return nil
   end
 
   local rem = self:GetAuraRemainingSecondsByName(spellName, unit)
+  if not rem or rem <= 0 then
+    return nil
+  end
+
+  if comp == ">=" then
+    return rem >= threshold
+  elseif comp == "<=" then
+    return rem <= threshold
+  elseif comp == "==" then
+    return rem == threshold
+  end
+  return nil
+end
+
+
+function DoiteTrack:RemainingPassesBySpellId(spellId, unit, comp, threshold)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 or not unit or not comp or threshold == nil then
+    return nil
+  end
+
+  local rem = self:GetAuraRemainingSecondsBySpellId(spellId, unit)
   if not rem or rem <= 0 then
     return nil
   end
@@ -2488,8 +2638,52 @@ function DoiteTrack:GetAuraOwnershipByName(spellName, unit)
     end
   end
 
+  if (not hasMine) and (not hasOther) then
+    local wantNorm = entry.normName
+    if wantNorm and _AuraHasNormName(unit, wantNorm, isDebuff) then
+      -- Conservative ownership fallback: if aura is present by name but we have no
+      -- player-confirmed timer, treat as "other" until proven mine.
+      hasOther = true
+    end
+  end
+
   local ownerKnown = (hasMine or hasOther)
   return bestRem, false, bestSpellId, hasMine, hasOther, ownerKnown
+end
+
+function DoiteTrack:GetAuraOwnershipBySpellId(spellId, unit)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 or not unit then
+    return nil, false, nil, false, false, false
+  end
+
+  local entry = TrackedBySpellId[spellId]
+  if not entry then
+    return nil, false, nil, false, false, false
+  end
+
+  if not _UnitExistsFlag(unit) then
+    return nil, false, nil, false, false, false
+  end
+
+  local guid = _GetUnitGuidSafe(unit)
+  if not guid then
+    return nil, false, nil, false, false, false
+  end
+
+  local isDebuff = (entry.kind == "Debuff")
+  if not _AuraHasSpellId(unit, spellId, isDebuff) then
+    _ClearAuraStateForGuidSpell(guid, spellId)
+    return nil, false, nil, false, false, false
+  end
+
+  local now = GetTime and GetTime() or 0
+  local rem = _GetRemainingFromState(guid, spellId, now)
+  if rem and rem > 0 then
+    return rem, false, spellId, true, false, true
+  end
+
+  return nil, false, spellId, false, true, true
 end
 
 ---------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Support icons/config entries that reference auras by spell ID instead of name to improve accuracy across ranks and localized names.
- Ensure remaining-time, ownership and stack counters work when auras are referenced by spell ID and when buff-cap/debuff overflow occurs.
- Make DoiteTrack/DoitePlayerAuras cooperate with spell-id based lookups so ownership and timers remain correct in mixed name/id setups.

### Description
- Add explicit `Addedviaspellid` handling throughout `DoiteConditions`, `DoitePlayerAuras` and `DoiteTrack` and thread a `useSpellId`/`auraSpellId` parameter through remaining/ownership/stack paths.
- Extend `DoitePlayerAuras` with `activeBuffSpellIds`/`activeDebuffSpellIds` caches, update `UpdateAuras`, and add `HasBuffSpellId`, `HasDebuffSpellId`, `GetActiveAuraSlotBySpellId`, `GetBuffStacksBySpellId`, and `GetDebuffStacksBySpellId` helpers.
- Add spell-id based APIs to tracking: `GetAuraRemainingSecondsBySpellId`, `RemainingPassesBySpellId`, and `GetAuraOwnershipBySpellId`, plus helper `_AuraHasNormName` and logic to seed name-tracked `onlyMine` entries with discovered spell IDs and to arm timers when a target aura is immediately verifiable.
- Update condition evaluation (`DoiteConditions`) to use spell-id lookups for presence, stacks and remaining-time when `Addedviaspellid` is set and to bail early for invalid spell IDs.
- Update player aura remaining helper and `_GetAuraStacksOnUnit` to accept spell-id parameters and respect `Addedviaspellid` semantics.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a584e6e270832ab62ffcbb795046ab)