### PR TITLE
Fix initial owner filtering for name-matched aura tracking

### DIFF
--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -499,6 +499,46 @@ local function _AuraHasSpellId(unit, spellId, isDebuff)
   return false
 end
 
+local function _CollectAuraSpellIdsMatchingName(unit, isDebuff, normName, out)
+  if not unit or not normName or normName == "" then
+    return out
+  end
+
+  local auras = _GetUnitAuraTable(unit, isDebuff)
+  if type(auras) ~= "table" then
+    return out
+  end
+
+  out = out or {}
+
+  local function maybeAddSid(rawSid)
+    local sid = tonumber(rawSid) or 0
+    if sid <= 0 or out[sid] then
+      return
+    end
+
+    local n = _GetSpellNameRank(sid)
+    if _NormSpellName(n) == normName then
+      out[sid] = true
+    end
+  end
+
+  local k
+  for k in pairs(auras) do
+    maybeAddSid(k)
+  end
+
+  local n = table.getn(auras)
+  if n and n > 0 then
+    local i
+    for i = 1, n do
+      maybeAddSid(auras[i])
+    end
+  end
+
+  return out
+end
+
 ---------------------------------------------------------------
 -- Spell name/rank helper (kept compatible)
 ---------------------------------------------------------------
@@ -2558,6 +2598,35 @@ function DoiteTrack:GetAuraOwnershipByName(spellName, unit)
       end
     else
       _ClearAuraStateForGuidSpell(guid, sid)
+    end
+  end
+
+  -- Name-tracked entries can be queried before we've discovered rank spellIds.
+  -- On that first pass, learn any spellIds currently present on the unit that
+  -- normalize to this aura name, then immediately evaluate ownership from them.
+  if (not hasMine) and (not hasOther) and entry.normName then
+    local discovered = _CollectAuraSpellIdsMatchingName(unit, isDebuff, entry.normName)
+    if discovered then
+      for sid in pairs(discovered) do
+        if not entry.spellIds[sid] then
+          entry.spellIds[sid] = true
+        end
+
+        if _AuraHasSpellId(unit, sid, isDebuff) then
+          local rem = _GetRemainingFromState(guid, sid, now)
+          if rem and rem > 0 then
+            hasMine = true
+            if (not bestRem) or rem > bestRem then
+              bestRem = rem
+              bestSpellId = sid
+            end
+          else
+            hasOther = true
+          end
+        else
+          _ClearAuraStateForGuidSpell(guid, sid)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation
- Name-matched aura tracking (using `displayName`) could report unknown ownership on first evaluation after reload, allowing both `onlyMine` and `onlyOthers` icons to show simultaneously. The intent is to ensure ownership is resolved immediately even before rank-specific spell IDs are learned from cast events.

### Description
- Added `_CollectAuraSpellIdsMatchingName(unit, isDebuff, normName, out)` to `Modules/DoiteTrack.lua` to scan the live aura table, resolve spell names via `_GetSpellNameRank`, normalize them with `_NormSpellName`, and collect matching spell IDs.
- Extended `DoiteTrack:GetAuraOwnershipByName` to, when no ownership was found from `entry.spellIds`, discover any matching spell IDs currently present on the queried unit, merge them into `entry.spellIds`, and immediately re-evaluate `hasMine`/`hasOther` from those IDs.
- This change seeds name-tracked entries with present rank spell IDs on first lookup so owner filtering (`onlyMine` / `onlyOthers`) behaves correctly on the initial match.

### Testing
- Attempted a local Lua load/syntax check using `lua -e "assert(loadfile('Modules/DoiteTrack.lua'))"`, but the `lua` binary is not available in this environment so the check could not be executed (failed due to missing runtime).
- No further automated runtime or CI tests were available in the execution environment; changes were validated by inspecting the modified `Modules/DoiteTrack.lua` logic and diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5ab038aac832a86fe4474607b963f)