### PR TITLE
Add icon text override inputs for aura/item remaining and aura stacks

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2496,6 +2496,29 @@ local function _PlayerAuraRemainingSeconds(auraName, auraSpellId, addedViaSpellI
   return nil
 end
 
+local function _ResolvePlayerAuraTextOverride(overrideValue, fallbackName, fallbackSpellId, fallbackUseSpellId)
+  local v = overrideValue
+  if type(v) == "string" then
+    v = str_gsub(v, "^%s*(.-)%s*$", "%1")
+    if v == "" then
+      v = nil
+    end
+  else
+    v = nil
+  end
+
+  if not v then
+    return fallbackName, fallbackSpellId, fallbackUseSpellId
+  end
+
+  local sid = tonumber(v)
+  if sid and sid > 0 then
+    return fallbackName, sid, true
+  end
+
+  return v, 0, false
+end
+
 local function _DoiteTrackAuraOwnership(spellKey, unit, useSpellId)
   if not DoiteTrack or not spellKey or not unit then
     return nil, false, nil, false, false, false
@@ -6242,6 +6265,17 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
       local ci = dataTbl.conditions.item
 
       if ci.textTimeRemaining == true then
+        local ovName, ovSpellId, ovUseSpellId = _ResolvePlayerAuraTextOverride(ci.remOverride, nil, 0, false)
+        if ci.remOverride and (ovName or (ovUseSpellId and ovSpellId and ovSpellId > 0)) then
+          local remOverride = _PlayerAuraRemainingSeconds(ovName, ovSpellId, ovUseSpellId)
+          if remOverride and remOverride > 0 then
+            remText = _FmtRem(remOverride)
+            wantRem = (remText ~= nil)
+            frame._daSortRem = remOverride
+          end
+        end
+
+        if not wantRem then
         -- Reuse this later for stack counter too
         itemState = _EvaluateItemCoreState(dataTbl, ci)
 
@@ -6268,6 +6302,7 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
             frame._daSortRem = remItem
           end
         end
+        end
       end
 
       ----------------------------------------------------------------
@@ -6281,8 +6316,9 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
 
       if ca.textTimeRemaining == true then
         local auraName = dataTbl.displayName or dataTbl.name
-      local useSpellIdOnly = (dataTbl.Addedviaspellid == true)
-      local auraSpellId = tonumber(dataTbl.spellid) or 0
+        local useSpellIdOnly = (dataTbl.Addedviaspellid == true)
+        local auraSpellId = tonumber(dataTbl.spellid) or 0
+        auraName, auraSpellId, useSpellIdOnly = _ResolvePlayerAuraTextOverride(ca.remOverride, auraName, auraSpellId, useSpellIdOnly)
 
         local allowHelp = (ca.targetHelp == true)
         local allowHarm = (ca.targetHarm == true)
@@ -6357,6 +6393,7 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
       local useSpellIdOnly = (dataTbl.Addedviaspellid == true)
       local auraSpellId = tonumber(dataTbl.spellid) or 0
       local wantDebuff = (dataTbl.type == "Debuff")
+      auraName, auraSpellId, useSpellIdOnly = _ResolvePlayerAuraTextOverride(ca.stackOverride, auraName, auraSpellId, useSpellIdOnly)
 
       -- Resolve which unit to read stacks from (same semantics as CheckAuraConditions)
       local unitToCheck = nil
@@ -6386,6 +6423,7 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
       end
 
       if unitToCheck then
+        unitToCheck = "player"
         local cnt = _GetAuraStacksOnUnit(unitToCheck, auraName, wantDebuff, auraSpellId, useSpellIdOnly)
         if cnt and cnt >= 1 then
           local s = _DA_NumToStr(cnt)

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -2181,6 +2181,31 @@ local function CreateConditionsUI()
 
   condFrame.cond_aura_text_time = MakeCheck("DoiteCond_Aura_TextTime", "Icon text: Time remaining", 0, row11_y - 11)
   condFrame.cond_aura_text_stack = MakeCheck("DoiteCond_Aura_TextStack", "Icon text: Stacks", 0, row12_y+3)
+  condFrame.cond_aura_text_time_override = CreateFrame("EditBox", "DoiteCond_Aura_TextTimeOverride", _Parent(), "InputBoxTemplate")
+  condFrame.cond_aura_text_time_override:SetWidth(100)
+  condFrame.cond_aura_text_time_override:SetHeight(18)
+  condFrame.cond_aura_text_time_override:SetPoint("TOPLEFT", _Parent(), "TOPLEFT", 150, row11_y - 13)
+  condFrame.cond_aura_text_time_override:SetAutoFocus(false)
+  condFrame.cond_aura_text_time_override:SetJustifyH("LEFT")
+  condFrame.cond_aura_text_time_override:SetFontObject("GameFontNormalSmall")
+  condFrame.cond_aura_text_time_override:Hide()
+
+  condFrame.cond_aura_text_stack_override = CreateFrame("EditBox", "DoiteCond_Aura_TextStackOverride", _Parent(), "InputBoxTemplate")
+  condFrame.cond_aura_text_stack_override:SetWidth(100)
+  condFrame.cond_aura_text_stack_override:SetHeight(18)
+  condFrame.cond_aura_text_stack_override:SetPoint("TOPLEFT", _Parent(), "TOPLEFT", 150, row12_y+1)
+  condFrame.cond_aura_text_stack_override:SetAutoFocus(false)
+  condFrame.cond_aura_text_stack_override:SetJustifyH("LEFT")
+  condFrame.cond_aura_text_stack_override:SetFontObject("GameFontNormalSmall")
+  condFrame.cond_aura_text_stack_override:Hide()
+
+  condFrame.cond_aura_text_override_note = _Parent():CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+  condFrame.cond_aura_text_override_note:SetPoint("TOPLEFT", condFrame.cond_aura_text_stack_override, "BOTTOMLEFT", 0, -2)
+  condFrame.cond_aura_text_override_note:SetTextColor(1, 0.82, 0)
+  condFrame.cond_aura_text_override_note:SetText("Input separate aura Name or SpellID to override (on player based). Empty, falls back to default.")
+  condFrame.cond_aura_text_override_note:SetWidth(120)
+  condFrame.cond_aura_text_override_note:SetJustifyH("LEFT")
+  condFrame.cond_aura_text_override_note:Hide()
   SetSeparator("aura", 10, "TIME REMAINING & STACKS", true, true)
 
   -- Class-specific (combo points)
@@ -2416,6 +2441,14 @@ local function CreateConditionsUI()
   condFrame.cond_item_remaining_val:Hide()
   condFrame.cond_item_remaining_val_enter:Hide()
   condFrame.cond_item_text_time = MakeCheck("DoiteCond_Item_TextTime", "Icon text: Time remaining", 0, row12_y - 25)
+  condFrame.cond_item_text_time_override = CreateFrame("EditBox", "DoiteCond_Item_TextTimeOverride", _Parent(), "InputBoxTemplate")
+  condFrame.cond_item_text_time_override:SetWidth(100)
+  condFrame.cond_item_text_time_override:SetHeight(18)
+  condFrame.cond_item_text_time_override:SetPoint("TOPLEFT", _Parent(), "TOPLEFT", 150, row12_y - 27)
+  condFrame.cond_item_text_time_override:SetAutoFocus(false)
+  condFrame.cond_item_text_time_override:SetJustifyH("LEFT")
+  condFrame.cond_item_text_time_override:SetFontObject("GameFontNormalSmall")
+  condFrame.cond_item_text_time_override:Hide()
   SetSeparator("item", 12, "REMAINING TIME", true, true)
 
   -- CLASS-SPECIFIC (Combo points)
@@ -4399,6 +4432,7 @@ function UpdateItemStacksForMissing()
     local d = EnsureDBEntry(currentKey);
     d.conditions.aura = d.conditions.aura or {}
     d.conditions.aura.textTimeRemaining = this:GetChecked() and true or false
+    UpdateCondFrameForKey(currentKey)
     SafeRefresh();
     SafeEvaluate()
   end)
@@ -4410,6 +4444,7 @@ function UpdateItemStacksForMissing()
     local d = EnsureDBEntry(currentKey);
     d.conditions.aura = d.conditions.aura or {}
     d.conditions.aura.textStackCounter = this:GetChecked() and true or false
+    UpdateCondFrameForKey(currentKey)
     SafeRefresh();
     SafeEvaluate()
   end)
@@ -4535,6 +4570,82 @@ function UpdateItemStacksForMissing()
     SafeRefresh();
     SafeEvaluate()
   end)
+
+  local function _SaveAuraTextOverride(which)
+    if not currentKey then
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.aura = d.conditions.aura or {}
+    local ca = d.conditions.aura
+    local eb = (which == "stack") and condFrame.cond_aura_text_stack_override or condFrame.cond_aura_text_time_override
+    local txt = ""
+    if eb and eb.GetText then
+      txt = eb:GetText() or ""
+      txt = string.gsub(txt, "^%s*(.-)%s*$", "%1")
+    end
+    if which == "stack" then
+      ca.stackOverride = (txt ~= "") and txt or nil
+    else
+      ca.remOverride = (txt ~= "") and txt or nil
+    end
+    UpdateCondFrameForKey(currentKey)
+    SafeRefresh();
+    SafeEvaluate()
+  end
+
+  if condFrame.cond_aura_text_time_override then
+    condFrame.cond_aura_text_time_override:SetScript("OnEnterPressed", function(self)
+      _SaveAuraTextOverride("rem")
+      self:ClearFocus()
+    end)
+    condFrame.cond_aura_text_time_override:SetScript("OnEscapePressed", function(self)
+      self:ClearFocus()
+      UpdateCondFrameForKey(currentKey)
+    end)
+  end
+  if condFrame.cond_aura_text_stack_override then
+    condFrame.cond_aura_text_stack_override:SetScript("OnEnterPressed", function(self)
+      _SaveAuraTextOverride("stack")
+      self:ClearFocus()
+    end)
+    condFrame.cond_aura_text_stack_override:SetScript("OnEscapePressed", function(self)
+      self:ClearFocus()
+      UpdateCondFrameForKey(currentKey)
+    end)
+  end
+
+  local function _SaveItemTextOverride()
+    if not currentKey then
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.item = d.conditions.item or {}
+    local ci = d.conditions.item
+    local txt = ""
+    local eb = condFrame.cond_item_text_time_override
+    if eb and eb.GetText then
+      txt = eb:GetText() or ""
+      txt = string.gsub(txt, "^%s*(.-)%s*$", "%1")
+    end
+    ci.remOverride = (txt ~= "") and txt or nil
+    UpdateCondFrameForKey(currentKey)
+    SafeRefresh();
+    SafeEvaluate()
+  end
+
+  if condFrame.cond_item_text_time_override then
+    condFrame.cond_item_text_time_override:SetScript("OnEnterPressed", function(self)
+      _SaveItemTextOverride()
+      self:ClearFocus()
+    end)
+    condFrame.cond_item_text_time_override:SetScript("OnEscapePressed", function(self)
+      self:ClearFocus()
+      UpdateCondFrameForKey(currentKey)
+    end)
+  end
 
   -- dropdown initializers
   local function InitComparatorDD(ddframe, commitFunc)
@@ -8673,6 +8784,15 @@ local function UpdateConditionsUI(data)
     if condFrame.cond_aura_text_stack then
       condFrame.cond_aura_text_stack:Hide()
     end
+    if condFrame.cond_aura_text_time_override then
+      condFrame.cond_aura_text_time_override:Hide()
+    end
+    if condFrame.cond_aura_text_stack_override then
+      condFrame.cond_aura_text_stack_override:Hide()
+    end
+    if condFrame.cond_aura_text_override_note then
+      condFrame.cond_aura_text_override_note:Hide()
+    end
 
     if condFrame.cond_aura_power then
       condFrame.cond_aura_power:Hide()
@@ -8788,6 +8908,9 @@ local function UpdateConditionsUI(data)
     end
     if condFrame.cond_item_text_time then
       condFrame.cond_item_text_time:Hide()
+    end
+    if condFrame.cond_item_text_time_override then
+      condFrame.cond_item_text_time_override:Hide()
     end
     if condFrame.cond_item_enchant then
       condFrame.cond_item_enchant:Hide()
@@ -9382,6 +9505,15 @@ local ic = c.item or {}
           end
         end
       end
+
+      if condFrame.cond_item_text_time_override then
+        if allowTime and condFrame.cond_item_text_time:GetChecked() then
+          condFrame.cond_item_text_time_override:Show()
+          condFrame.cond_item_text_time_override:SetText(ic.remOverride or "")
+        else
+          condFrame.cond_item_text_time_override:Hide()
+        end
+      end
     end
 
     -- ITEM STACKS row (Item stacks + text stack counter)
@@ -9901,6 +10033,9 @@ local ic = c.item or {}
     _Hide(condFrame.cond_aura_stacks_val_enter)
     _Hide(condFrame.cond_aura_text_time)
     _Hide(condFrame.cond_aura_text_stack)
+    _Hide(condFrame.cond_aura_text_time_override)
+    _Hide(condFrame.cond_aura_text_stack_override)
+    _Hide(condFrame.cond_aura_text_override_note)
     _Hide(condFrame.cond_aura_cp_cb)
     _Hide(condFrame.cond_aura_cp_comp)
     _Hide(condFrame.cond_aura_cp_val)
@@ -9932,6 +10067,7 @@ local ic = c.item or {}
     _Hide(condFrame.cond_item_glow)
     _Hide(condFrame.cond_item_greyscale)
     _Hide(condFrame.cond_item_text_time)
+    _Hide(condFrame.cond_item_text_time_override)
     _Hide(condFrame.cond_item_enchant)
     _Hide(condFrame.cond_item_text_enchant)
     _Hide(condFrame.cond_item_stacks_cb)
@@ -10393,6 +10529,38 @@ local ic = c.item or {}
     else
       condFrame.cond_aura_text_time:Hide()
       condFrame.cond_aura_text_stack:Hide()
+    end
+
+    do
+      local showRemOv = (condFrame.cond_aura_text_time and condFrame.cond_aura_text_time:IsShown() and condFrame.cond_aura_text_time:GetChecked()) and true or false
+      local showStackOv = (condFrame.cond_aura_text_stack and condFrame.cond_aura_text_stack:IsShown() and condFrame.cond_aura_text_stack:GetChecked()) and true or false
+      local showAnyOv = showRemOv or showStackOv
+
+      if condFrame.cond_aura_text_time_override then
+        if showRemOv then
+          condFrame.cond_aura_text_time_override:Show()
+          condFrame.cond_aura_text_time_override:SetText((c.aura and c.aura.remOverride) or "")
+        else
+          condFrame.cond_aura_text_time_override:Hide()
+        end
+      end
+
+      if condFrame.cond_aura_text_stack_override then
+        if showStackOv then
+          condFrame.cond_aura_text_stack_override:Show()
+          condFrame.cond_aura_text_stack_override:SetText((c.aura and c.aura.stackOverride) or "")
+        else
+          condFrame.cond_aura_text_stack_override:Hide()
+        end
+      end
+
+      if condFrame.cond_aura_text_override_note then
+        if showAnyOv then
+          condFrame.cond_aura_text_override_note:Show()
+        else
+          condFrame.cond_aura_text_override_note:Hide()
+        end
+      end
     end
 
     -- Row 11: Aura Power (like ability)


### PR DESCRIPTION
### Motivation
- Provide per-spell overrides so icon text for remaining time and stacks can display values from a separate player-based aura (by name or SpellID) without changing existing UI layout.
- Allow users to type a free-text override next to the existing "Icon text" toggles and persist that override to the DB for runtime use.

### Description
- Added free-text edit boxes in the conditions editor: `cond_aura_text_time_override` and `cond_aura_text_stack_override` for auras and `cond_item_text_time_override` for items, positioned to the right of the existing checkboxes and hidden by default, with the helper note capped to width `120` and styled as requested.
- Persisted override values into the DB on Enter (aura fields saved to `conditions.aura.remOverride` / `conditions.aura.stackOverride`, item saved to `conditions.item.remOverride`), and wired `UpdateCondFrameForKey` + refresh so visibility updates immediately when toggling checkboxes or switching categories.
- Implemented `_ResolvePlayerAuraTextOverride` helper in `Modules/DoiteConditions.lua` and integrated it into overlay logic so: (a) aura remaining text uses `remOverride` when present, (b) aura stacks use `stackOverride` and are always read from the player, and (c) item remaining text will try `remOverride` (player aura) first and fall back to the existing item cooldown/enchant behavior if no override result is available.
- Kept all existing UI sizes/placements intact and used the same show/hide patterns already in `DoiteEdit`, reusing `UpdateCondFrameForKey`, `SafeRefresh`, and `SafeEvaluate` to avoid UI regressions.

### Testing
- Ran repository checks and inspected diffs with `git diff` and `git status`, and committed the changes successfully (commit present on branch).
- Verified UI wiring by grepping/inspecting `Modules/DoiteEdit.lua` and `Modules/DoiteConditions.lua` to ensure new fields, hide/show logic, and DB save handlers are present; those inspections succeeded.
- Attempted Lua byte-compile checks (`luac -p ...`) and `lua -v` to validate syntax but the environment lacks Lua/luac so the compile check could not be run (automated check failed due to missing executable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a7056853cc832aa8009a8bd0f5cfbe)