### PR TITLE
Resolve spellId-added aura icons using spell icon API

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -246,6 +246,25 @@ local function DoiteAuras_RebuildSpellTextureCache()
     end
 end
 
+local function DA_GetSpellTextureById(spellId)
+    local sid = tonumber(spellId)
+    if not sid or sid <= 0 then
+        return nil
+    end
+
+    if type(GetSpellRecField) == "function" and type(GetSpellIconTexture) == "function" then
+        local okIconId, iconId = pcall(GetSpellRecField, sid, "spellIconID")
+        if okIconId and iconId and iconId > 0 then
+            local okTex, tex = pcall(GetSpellIconTexture, iconId)
+            if okTex and type(tex) == "string" and tex ~= "" then
+                return tex
+            end
+        end
+    end
+
+    return nil
+end
+
 -- Event hook: rebuild on login/world and whenever the spellbook changes (talent/build swaps)
 local _daSpellTex = CreateFrame("Frame", "DoiteSpellTex")
 _daSpellTex:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -3346,14 +3365,13 @@ addBtn:SetScript("OnClick", function()
       entry.Addedviaspellid = true
   end
 
-  -- Auto-prime texture: SpellID-added Buff/Debuff: try Nampower icon lookup immediately. If it returns nil, do NOTHING here so the existing fallback logic below (cache/siblings) and DoiteConditions "seen" updates remain unchanged.
+  -- Auto-prime texture: SpellID-added Buff/Debuff: try Nampower spell texture lookup immediately.
+  -- If it returns nil, do NOTHING here so existing fallback logic below (cache/siblings) and DoiteConditions "seen" updates remain unchanged.
   if spellIdStr then
-      if type(GetItemIconTexture) == "function" then
-          local ok, tex = pcall(GetItemIconTexture, tonumber(spellIdStr))
-          if ok and tex and tex ~= "" then
-              cache[name]       = tex
-              entry.iconTexture = tex
-          end
+      local tex = DA_GetSpellTextureById(spellIdStr)
+      if tex then
+          cache[name]       = tex
+          entry.iconTexture = tex
       end
   end
 


### PR DESCRIPTION
### Motivation
- Fix incorrect initial icon texture when adding Buff/Debuff entries by numeric spell ID (examples: potion/consumable spell IDs yielding item icons before being corrected).
- Use Nampower spell metadata instead of item-icon lookup to seed iconTexture immediately when possible.

### Description
- Added helper `DA_GetSpellTextureById(spellId)` to centralize safe lookup of a spell icon via `GetSpellRecField(spellId, "spellIconID")` + `GetSpellIconTexture(iconId)` with `tonumber`/`pcall` and non-empty-string guards in `DoiteAuras.lua`.
- Replaced the previous `GetItemIconTexture`-based priming path for spell-ID-added Buff/Debuff entries with a call to `DA_GetSpellTextureById(spellId)` so initial `entry.iconTexture` is seeded from the spell icon when available.
- Kept all existing fallback behavior unchanged: when immediate spell icon resolution fails the code still falls back to cache/sibling logic and runtime "seen" updates in `Modules/DoiteConditions.lua`.
- Change is limited to `DoiteAuras.lua` and does not alter the runtime aura-scanning logic which updates names/textures when auras are observed.

### Testing
- Searched the codebase for icon-related APIs with `rg -n "GetSpellTexture\(|GetSpellIconTexture\(|GetItemIconTexture\("` to verify the new lookup replaces the inappropriate `GetItemIconTexture` use; the search confirmed the new helper is used for the spellId add path.
- Inspected modified regions with `git diff` and file snippets to validate the new helper and the replacement call appear in `DoiteAuras.lua` as intended.
- Attempted a Lua bytecode syntax check with `luac -p DoiteAuras.lua`, but `luac` is not available in this environment so a local syntax binary check could not be performed.
- No automated unit tests exist for this addon code; the change is small and guarded with `pcall` to avoid runtime errors if Nampower APIs are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a73a2d33d4832aadc79542dc6298fb)