### PR TITLE
Add resilient spell texture lookup and use it for spell-ID icon priming

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -246,6 +246,25 @@ local function DoiteAuras_RebuildSpellTextureCache()
     end
 end
 
+local function DA_GetSpellTextureById(spellId)
+    local sid = tonumber(spellId)
+    if not sid or sid <= 0 then
+        return nil
+    end
+
+    if type(GetSpellRecField) == "function" and type(GetSpellIconTexture) == "function" then
+        local okIconId, iconId = pcall(GetSpellRecField, sid, "spellIconID")
+        if okIconId and iconId and iconId > 0 then
+            local okTex, tex = pcall(GetSpellIconTexture, iconId)
+            if okTex and type(tex) == "string" and tex ~= "" then
+                return tex
+            end
+        end
+    end
+
+    return nil
+end
+
 -- Event hook: rebuild on login/world and whenever the spellbook changes (talent/build swaps)
 local _daSpellTex = CreateFrame("Frame", "DoiteSpellTex")
 _daSpellTex:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -3346,14 +3365,13 @@ addBtn:SetScript("OnClick", function()
       entry.Addedviaspellid = true
   end
 
-  -- Auto-prime texture: SpellID-added Buff/Debuff: try Nampower icon lookup immediately. If it returns nil, do NOTHING here so the existing fallback logic below (cache/siblings) and DoiteConditions "seen" updates remain unchanged.
+  -- Auto-prime texture: SpellID-added Buff/Debuff: try Nampower spell texture lookup immediately.
+  -- If it returns nil, do NOTHING here so existing fallback logic below (cache/siblings) and DoiteConditions "seen" updates remain unchanged.
   if spellIdStr then
-      if type(GetItemIconTexture) == "function" then
-          local ok, tex = pcall(GetItemIconTexture, tonumber(spellIdStr))
-          if ok and tex and tex ~= "" then
-              cache[name]       = tex
-              entry.iconTexture = tex
-          end
+      local tex = DA_GetSpellTextureById(spellIdStr)
+      if tex then
+          cache[name]       = tex
+          entry.iconTexture = tex
       end
   end
 

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -74,19 +74,19 @@ local function _NP_SpellNameAndTexture(spellId)
   end
 
   local name = nil
-  if GetSpellNameAndRankForId then
-    local n = GetSpellNameAndRankForId(spellId)
-    if type(n) == "string" and n ~= "" then
+  if type(GetSpellNameAndRankForId) == "function" then
+    local okName, n = pcall(GetSpellNameAndRankForId, spellId)
+    if okName and type(n) == "string" and n ~= "" then
       name = n
     end
   end
 
   local tex = nil
-  if GetSpellRecField and GetSpellIconTexture then
-    local iconId = GetSpellRecField(spellId, "spellIconID")
-    if iconId and iconId > 0 then
-      local t = GetSpellIconTexture(iconId)
-      if type(t) == "string" and t ~= "" then
+  if type(GetSpellRecField) == "function" and type(GetSpellIconTexture) == "function" then
+    local okIconId, iconId = pcall(GetSpellRecField, spellId, "spellIconID")
+    if okIconId and iconId and iconId > 0 then
+      local okTex, t = pcall(GetSpellIconTexture, iconId)
+      if okTex and type(t) == "string" and t ~= "" then
         tex = t
       end
     end


### PR DESCRIPTION
### Motivation

- Prevent runtime errors and improve icon priming when game API functions are missing or throw, and make spell texture/name lookups resilient across API changes.

### Description

- Add helper `DA_GetSpellTextureById(spellId)` which safely queries `GetSpellRecField` and `GetSpellIconTexture` under `pcall` and returns a texture path or `nil`.
- Replace the previous `GetItemIconTexture`-based priming for spell-ID-added buffs/debuffs with a call to `DA_GetSpellTextureById` so spell icons are correctly auto-primed when available.
- Harden `_NP_SpellNameAndTexture` and other call sites by checking function types and wrapping calls in `pcall` so missing or throwing API functions do not error the addon.
- Minor comment and formatting cleanup around the spell texture cache and event handling logic.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a73a2d33d4832aadc79542dc6298fb)