### PR TITLE
Replace fixed Group 1-10 UI with dynamic Group/Category editor (DoiteGroup)

### DIFF
--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -718,16 +718,6 @@ ClearDropdown = function(dd)
   dd._initializedForType = nil
 end
 
-local function BuildGroupLeaders()
-  local leaders = {}
-  for k, v in pairs(DoiteAurasDB.spells) do
-    if v.group and v.isLeader then
-      leaders[v.group] = k
-    end
-  end
-  return leaders
-end
-
 SafeEvaluate = function()
   DoiteEdit_QueueHeavy()
 end
@@ -847,78 +837,6 @@ local function _DA_ApplySliderRanges()
   end
 end
 
-
--- Internal: initialize group dropdown contents for current data
-local function InitGroupDropdown(dd, data)
-  UIDropDownMenu_Initialize(dd, function(frame, level, menuList)
-    local info
-    local choices = { "No" }
-    for i = 1, 10 do
-      table.insert(choices, "Group " .. tostring(i))
-    end
-
-    for _, choice in ipairs(choices) do
-      info = {}
-      info.text = choice
-      info.value = choice
-      local pickedChoice = choice
-      info.func = function(button)
-        local picked = (button and button.value) or pickedChoice
-        if not currentKey then
-          return
-        end
-        local d = EnsureDBEntry(currentKey)
-
-        if picked == "No" then
-          d.group = nil
-          d.isLeader = false
-        else
-          local leaders = BuildGroupLeaders()
-          d.group = picked
-          if not leaders[picked] then
-            d.isLeader = true
-          else
-            if leaders[picked] ~= currentKey then
-              d.isLeader = false
-            end
-          end
-        end
-
-        -- Custom auras: clear stale runtime data and auto-save when group changes
-        if d.type == "Custom" then
-          d._daCustomRuntime = {}
-          if condFrame and condFrame.cond_custom_function_save then
-            condFrame.cond_custom_function_save:Click()
-          end
-        end
-
-        UIDropDownMenu_SetSelectedValue(dd, picked)
-        UIDropDownMenu_SetText(picked, dd)
-        CloseDropDownMenus()
-        UpdateCondFrameForKey(currentKey)
-
-        -- Queue the normal batched refresh/evaluate
-        SafeRefresh()
-        SafeEvaluate()
-
-        -- if /da is open, force an immediate list refresh so the icon visibly moves to the selected group right away (no reopen needed).
-        if DoiteAurasFrame and DoiteAurasFrame.IsShown and DoiteAurasFrame:IsShown() then
-          if DoiteAuras_RefreshList then
-            pcall(DoiteAuras_RefreshList)
-          end
-        end
-      end
-
-      if data and ((not data.group and choice == "No") or (data.group == choice)) then
-        info.checked = true
-      else
-        info.checked = false
-      end
-
-      UIDropDownMenu_AddButton(info)
-    end
-  end)
-end
 
 -- Internal: initialize growth direction dropdown (leader-only control)
 local function InitGrowthDropdown(dd, data)
@@ -2524,7 +2442,7 @@ local function CreateConditionsUI()
   condFrame.categoryCheck = CreateFrame("CheckButton", "DoiteCond_Category_Check", condFrame, "UICheckButtonTemplate")
   condFrame.categoryCheck:SetWidth(20);
   condFrame.categoryCheck:SetHeight(20)
-  condFrame.categoryCheck:SetPoint("Left", condFrame.groupDD, "Right", -10, 0)
+  condFrame.categoryCheck:SetPoint("TOPLEFT", condFrame.groupLabel, "BOTTOMLEFT", 0, -4)
   condFrame.categoryCheck.text = condFrame.categoryCheck:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
   condFrame.categoryCheck.text:SetPoint("LEFT", condFrame.categoryCheck, "RIGHT", 4, 0)
   condFrame.categoryCheck.text:SetText("Categorize")
@@ -8332,48 +8250,12 @@ local function UpdateConditionsUI(data)
   ----------------------------------------------------------------
   if condFrame.categoryCheck and condFrame.categoryInput and condFrame.categoryButton
       and condFrame.categoryLabel and condFrame.categoryDD then
-
-    if data.group then
-      -- When grouped: hide and auto-uncheck the category UI
-      condFrame.categoryCheck:SetChecked(false)
-      condFrame.categoryCheck:Hide()
-      condFrame.categoryInput:Hide()
-      condFrame.categoryButton:Hide()
-      condFrame.categoryLabel:Hide()
-      condFrame.categoryDD:Hide()
-    else
-      -- Not grouped: category UI is available
-      condFrame.categoryCheck:Show()
-
-      local dcat = data.category
-      local isOn = (dcat ~= nil and dcat ~= "")
-
-      condFrame.categoryCheck:SetChecked(isOn)
-
-      if isOn then
-        condFrame.categoryInput:Show()
-        condFrame.categoryButton:Show()
-        condFrame.categoryLabel:Show()
-        condFrame.categoryDD:Show()
-        if Category_RefreshDropdown then
-          Category_RefreshDropdown(dcat)
-        end
-      else
-        condFrame.categoryInput:Hide()
-        condFrame.categoryButton:Hide()
-        condFrame.categoryLabel:Hide()
-        condFrame.categoryDD:Hide()
-        condFrame.categoryInput:SetText("")
-        if Category_RefreshDropdown then
-          -- Still refresh so "(Empty)" or "Select" is correct when user ticks the box
-          Category_RefreshDropdown(nil)
-        end
-      end
-
-      if Category_UpdateButtonState then
-        Category_UpdateButtonState()
-      end
-    end
+    condFrame.categoryCheck:SetChecked(false)
+    condFrame.categoryCheck:Hide()
+    condFrame.categoryInput:Hide()
+    condFrame.categoryButton:Hide()
+    condFrame.categoryLabel:Hide()
+    condFrame.categoryDD:Hide()
   end
 
   -- ABILITY
@@ -11086,133 +10968,20 @@ function UpdateCondFrameForKey(key)
   end
   condFrame.header:SetText("Edit: " .. (data.displayName or key) .. " " .. typeColor .. "(" .. (data.type or "") .. ")|r")
 
-  -- Initialize group dropdown contents (pass current data to get 'checked' right)
-  if condFrame.groupDD then
-    InitGroupDropdown(condFrame.groupDD, data)
-    local sel = data.group or "No"
-    UIDropDownMenu_SetSelectedValue(condFrame.groupDD, sel)
-    UIDropDownMenu_SetText(sel, condFrame.groupDD)
-  end
-
-  -- Leader checkbox logic & leader-only controls
-  if condFrame.leaderCB then
-    if not data.group then
-      condFrame.leaderCB:Hide()
-      if condFrame.growthDD then
-        condFrame.growthDD:Hide()
-      end
-      if condFrame.numAurasLabel then
-        condFrame.numAurasLabel:Hide()
-      end
-      if condFrame.numAurasDD then
-        condFrame.numAurasDD:Hide()
-      end
-      if condFrame.spacingLabel then
-        condFrame.spacingLabel:Hide()
-      end
-      if condFrame.spacingEdit then
-        condFrame.spacingEdit:Hide()
-      end
-      if condFrame.spacingSlider then
-        condFrame.spacingSlider:Hide()
-      end
-    else
-      condFrame.leaderCB:Show()
-      local leaders = BuildGroupLeaders()
-      local leaderKey = leaders[data.group]
-      if not leaderKey then
-        data.isLeader = true
-        condFrame.leaderCB:SetChecked(true)
-        condFrame.leaderCB:Disable()
-        if condFrame.growthDD then
-          condFrame.growthDD:Show()
-          InitGrowthDropdown(condFrame.growthDD, data)
-          UIDropDownMenu_SetSelectedValue(condFrame.growthDD, data.growth or "Horizontal Right")
-          UIDropDownMenu_SetText(data.growth or "Horizontal Right", condFrame.growthDD)
-        end
-        if condFrame.numAurasLabel and condFrame.numAurasDD then
-          condFrame.numAurasLabel:Show()
-          condFrame.numAurasDD:Show()
-          InitNumAurasDropdown(condFrame.numAurasDD, data)
-          UIDropDownMenu_SetSelectedValue(condFrame.numAurasDD, data.numAuras or 5)
-          UIDropDownMenu_SetText(tostring(data.numAuras or 5), condFrame.numAurasDD)
-        end
-        if condFrame.spacingLabel and condFrame.spacingEdit then
-          condFrame.spacingLabel:Show()
-          condFrame.spacingEdit:Show()
-          local s = data.spacing
-          if not s then
-            local settings = (DoiteAurasDB and DoiteAurasDB.settings)
-            s = (settings and settings.spacing) or 8
-          end
-          condFrame.spacingEdit:SetText(tostring(s))
-          if condFrame.spacingSlider then
-             condFrame.spacingSlider:Show()
-             condFrame.spacingSlider:SetValue(s)
-          end
-        end
-      else
-        if leaderKey == key then
-          condFrame.leaderCB:SetChecked(true)
-          condFrame.leaderCB:Disable()
-          if condFrame.growthDD then
-            condFrame.growthDD:Show()
-            InitGrowthDropdown(condFrame.growthDD, data)
-            UIDropDownMenu_SetSelectedValue(condFrame.growthDD, data.growth or "Horizontal Right")
-            UIDropDownMenu_SetText(data.growth or "Horizontal Right", condFrame.growthDD)
-          end
-          if condFrame.numAurasLabel and condFrame.numAurasDD then
-            condFrame.numAurasLabel:Show()
-            condFrame.numAurasDD:Show()
-            InitNumAurasDropdown(condFrame.numAurasDD, data)
-            UIDropDownMenu_SetSelectedValue(condFrame.numAurasDD, data.numAuras or 5)
-            UIDropDownMenu_SetText(tostring(data.numAuras or 5), condFrame.numAurasDD)
-          end
-          if condFrame.spacingLabel and condFrame.spacingEdit then
-            condFrame.spacingLabel:Show()
-            condFrame.spacingEdit:Show()
-            local s = data.spacing
-            if not s then
-              local settings = (DoiteAurasDB and DoiteAurasDB.settings)
-              s = (settings and settings.spacing) or 8
-            end
-            condFrame.spacingEdit:SetText(tostring(s))
-            if condFrame.spacingSlider then
-               condFrame.spacingSlider:Show()
-               condFrame.spacingSlider:SetValue(s)
-            end
-          end
-        else
-          condFrame.leaderCB:SetChecked(false)
-          condFrame.leaderCB:Enable()
-          if condFrame.growthDD then
-            condFrame.growthDD:Hide()
-          end
-          if condFrame.numAurasLabel then
-            condFrame.numAurasLabel:Hide()
-          end
-          if condFrame.numAurasDD then
-            condFrame.numAurasDD:Hide()
-          end
-          if condFrame.spacingLabel then
-            condFrame.spacingLabel:Hide()
-          end
-          if condFrame.spacingEdit then
-            condFrame.spacingEdit:Hide()
-          end
-          if condFrame.spacingSlider then
-            condFrame.spacingSlider:Hide()
-          end
-        end
-      end
-    end
+  if condFrame.DoiteGroupUIRefresh then
+    condFrame:DoiteGroupUIRefresh(key)
   end
 
   -- Update Conditions UI (always visible area between top and POS & SIZE)
   UpdateConditionsUI(data)
 
   -- Show/hide Position & Size section (only when no group OR leader)
-  if (not data.group) or data.isLeader then
+  local showPosSize = (not data.group) or data.isLeader
+  if condFrame.DoiteGroupUIIsLeaderOrFree then
+    showPosSize = condFrame:DoiteGroupUIIsLeaderOrFree()
+  end
+
+  if showPosSize then
     if condFrame.groupTitle3 then
       condFrame.groupTitle3:Show()
     end
@@ -11399,22 +11168,9 @@ function DoiteConditions_Show(key)
 
     condFrame.groupLabel = condFrame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     condFrame.groupLabel:SetPoint("TOPLEFT", condFrame, "TOPLEFT", 20, -68)
-    condFrame.groupLabel:SetText("Group this Aura?")
-
-    condFrame.groupDD = CreateFrame("Frame", "DoiteConditions_GroupDD", condFrame, "UIDropDownMenuTemplate")
-    condFrame.groupDD:SetPoint("LEFT", condFrame.groupLabel, "RIGHT", -10, -2)
-    if UIDropDownMenu_SetWidth then
-      pcall(UIDropDownMenu_SetWidth, 75, condFrame.groupDD)
-    end
-
-    condFrame.leaderCB = CreateFrame("CheckButton", nil, condFrame, "UICheckButtonTemplate")
-    condFrame.leaderCB:SetWidth(20);
-    condFrame.leaderCB:SetHeight(20)
-    condFrame.leaderCB:SetPoint("Left", condFrame.groupDD, "Right", -10, 0)
-    condFrame.leaderCB.text = condFrame.leaderCB:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    condFrame.leaderCB.text:SetPoint("LEFT", condFrame.leaderCB, "RIGHT", 2, 0)
-    condFrame.leaderCB.text:SetText("Aura group leader")
-    condFrame.leaderCB:Hide()
+    condFrame.groupLabel:SetText("If you want to Group or Categorize this icon, select an option below:")
+    condFrame.groupLabel:SetWidth(315)
+    condFrame.groupLabel:SetJustifyH("LEFT")
 
     condFrame.growthDD = CreateFrame("Frame", "DoiteConditions_GrowthDD", condFrame, "UIDropDownMenuTemplate")
     condFrame.growthDD:SetPoint("BOTTOMLEFT", condFrame.groupLabel, "BOTTOMLEFT", -18, -43)
@@ -11497,64 +11253,17 @@ function DoiteConditions_Show(key)
       this:SetText(tostring(val))
     end)
 
-    -- leaderCB click behavior
-    condFrame.leaderCB:SetScript("OnClick", function(self)
-      local cb = self or (condFrame and condFrame.leaderCB)
-      if not currentKey then
-        if cb then
-          cb:SetChecked(false)
-        end
-        return
-      end
-      local data = DoiteAurasDB.spells[currentKey]
-      if not data or not data.group then
-        if cb then
-          cb:SetChecked(false)
-          cb:Hide()
-        end
-        return
-      end
+    condFrame.InitGrowthDropdown = InitGrowthDropdown
+    condFrame.InitNumAurasDropdown = InitNumAurasDropdown
 
-      if cb and cb:GetChecked() then
-        local leaders = BuildGroupLeaders()
-        local prev = leaders[data.group]
-        if prev and prev ~= currentKey and DoiteAurasDB.spells[prev] then
-          DoiteAurasDB.spells[prev].isLeader = false
-        end
-        data.isLeader = true
-        cb:SetChecked(true)
-        cb:Disable()
-
-        if condFrame.growthDD then
-          condFrame.growthDD:Show()
-          InitGrowthDropdown(condFrame.growthDD, data)
-          UIDropDownMenu_SetSelectedValue(condFrame.growthDD, data.growth or "Horizontal Right")
-          UIDropDownMenu_SetText(data.growth or "Horizontal Right", condFrame.growthDD)
-        end
-        if condFrame.numAurasLabel and condFrame.numAurasDD then
-          condFrame.numAurasLabel:Show()
-          condFrame.numAurasDD:Show()
-          InitNumAurasDropdown(condFrame.numAurasDD, data)
-          UIDropDownMenu_SetSelectedValue(condFrame.numAurasDD, data.numAuras or 5)
-          UIDropDownMenu_SetText(tostring(data.numAuras or 5), condFrame.numAurasDD)
-        end
-
-        if condFrame.spacingLabel and condFrame.spacingEdit then
-          condFrame.spacingLabel:Show()
-          condFrame.spacingEdit:Show()
-          local s = data.spacing
-          if not s then
-            local settings = (DoiteAurasDB and DoiteAurasDB.settings)
-            s = (settings and settings.spacing) or 8
-          end
-          condFrame.spacingEdit:SetText(tostring(s))
-        end
-      end
-
-      SafeRefresh()
-      SafeEvaluate()
-      UpdateCondFrameForKey(currentKey)
-    end)
+    if DoiteGroup and DoiteGroup.AttachEditGroupUI then
+      DoiteGroup.AttachEditGroupUI(condFrame, {
+        Ensure = EnsureDBEntry,
+        SafeRefresh = SafeRefresh,
+        SafeEvaluate = SafeEvaluate,
+        ListRefresh = DoiteAuras_RefreshList,
+      })
+    end
 
     condFrame.groupTitle2 = condFrame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     condFrame.groupTitle2:SetPoint("TOPLEFT", condFrame, "TOPLEFT", 20, -155)

--- a/Modules/DoiteGroup.lua
+++ b/Modules/DoiteGroup.lua
@@ -888,3 +888,371 @@ _watch:RegisterEvent("ADDON_LOADED")
 _watch:SetScript("OnEvent", function()
   _HookApplyVisualsIfPresent()
 end)
+
+---------------------------------------------------------------
+-- Edit UI helpers for dynamic Group/Category management
+---------------------------------------------------------------
+local function _DA_DB()
+  DoiteAurasDB = DoiteAurasDB or {}
+  DoiteAurasDB.spells = DoiteAurasDB.spells or {}
+  DoiteAurasDB.categories = DoiteAurasDB.categories or {}
+  return DoiteAurasDB
+end
+
+local function _TrimName(v)
+  if not v then return "" end
+  return (string.gsub(v, "^%s*(.-)%s*$", "%1"))
+end
+
+local function _BuildNames(kind)
+  local db = _DA_DB()
+  local out = {}
+  local seen = {}
+
+  if kind == "category" then
+    local i = 1
+    while i <= table.getn(db.categories) do
+      local c = db.categories[i]
+      if c and c ~= "" and not seen[c] then
+        seen[c] = true
+        table.insert(out, c)
+      end
+      i = i + 1
+    end
+  end
+
+  for _, d in pairs(db.spells) do
+    local n = (kind == "group") and d.group or d.category
+    if n and n ~= "" and not seen[n] then
+      seen[n] = true
+      table.insert(out, n)
+    end
+  end
+
+  table.sort(out, function(a, b)
+    return string.upper(a) < string.upper(b)
+  end)
+  return out
+end
+
+local function _EnsureUniqueLeader(groupName)
+  if not groupName or groupName == "" then return end
+  local db = _DA_DB()
+  local leaderKey = nil
+  for k, d in pairs(db.spells) do
+    if d.group == groupName and d.isLeader then
+      leaderKey = k
+      break
+    end
+  end
+  if leaderKey then return end
+  for _, d in pairs(db.spells) do
+    if d.group == groupName then
+      d.isLeader = true
+      return
+    end
+  end
+end
+
+local function _CleanupCategoryIfEmpty(name)
+  local db = _DA_DB()
+  if not name or name == "" then return end
+  for _, d in pairs(db.spells) do
+    if d.category == name then return end
+  end
+  local i = 1
+  while i <= table.getn(db.categories) do
+    if db.categories[i] == name then
+      table.remove(db.categories, i)
+    else
+      i = i + 1
+    end
+  end
+end
+
+local function _CleanupGroupIfEmpty(name)
+  local db = _DA_DB()
+  if not name or name == "" then return end
+  for _, d in pairs(db.spells) do
+    if d.group == name then
+      _EnsureUniqueLeader(name)
+      return
+    end
+  end
+  if db.groupSort then db.groupSort[name] = nil end
+  if db.groupFixed then db.groupFixed[name] = nil end
+  if db.bucketCollapsed then db.bucketCollapsed[name] = nil end
+  if db.bucketDisabled then db.bucketDisabled[name] = nil end
+end
+
+function DoiteGroup.AttachEditGroupUI(frame, api)
+  if not frame or frame._dgEditorBuilt then return end
+  frame._dgEditorBuilt = true
+
+  local state = { step = "pick", mode = nil, rename = false, key = nil }
+  local function Ensure() return api and api.Ensure and api.Ensure(state.key) end
+  local function RefreshAll()
+    if api and api.SafeRefresh then api.SafeRefresh() end
+    if api and api.SafeEvaluate then api.SafeEvaluate() end
+    if api and api.ListRefresh then pcall(api.ListRefresh) end
+  end
+
+  local line = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+  line:SetPoint("TOPLEFT", frame, "TOPLEFT", 20, -68)
+  line:SetWidth(318)
+  line:SetJustifyH("LEFT")
+  frame.dgLine = line
+
+  local bNew = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bNew:SetWidth(70); bNew:SetHeight(20); bNew:SetPoint("TOPLEFT", line, "BOTTOMLEFT", 0, -6); bNew:SetText("New")
+  local bExisting = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bExisting:SetWidth(70); bExisting:SetHeight(20); bExisting:SetPoint("LEFT", bNew, "RIGHT", 6, 0); bExisting:SetText("Existing")
+
+  local bGroup = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bGroup:SetWidth(70); bGroup:SetHeight(20); bGroup:SetPoint("TOPLEFT", line, "BOTTOMLEFT", 0, -6); bGroup:SetText("Group")
+  local bCat = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bCat:SetWidth(70); bCat:SetHeight(20); bCat:SetPoint("LEFT", bGroup, "RIGHT", 6, 0); bCat:SetText("Category")
+  local bBackA = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bBackA:SetWidth(70); bBackA:SetHeight(20); bBackA:SetPoint("LEFT", bCat, "RIGHT", 6, 0); bBackA:SetText("Back")
+
+  local nameLbl = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+  nameLbl:SetPoint("TOPLEFT", line, "BOTTOMLEFT", 0, -10)
+  local nameIn = CreateFrame("EditBox", nil, frame, "InputBoxTemplate")
+  nameIn:SetWidth(120); nameIn:SetHeight(18); nameIn:SetAutoFocus(false); nameIn:SetPoint("LEFT", nameLbl, "RIGHT", 8, 0)
+  local bAdd = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bAdd:SetWidth(60); bAdd:SetHeight(20); bAdd:SetPoint("LEFT", nameIn, "RIGHT", 6, 0); bAdd:SetText("Add")
+  local bBackB = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bBackB:SetWidth(60); bBackB:SetHeight(20); bBackB:SetPoint("LEFT", bAdd, "RIGHT", 6, 0); bBackB:SetText("Back")
+
+  local bRename = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bRename:SetWidth(70); bRename:SetHeight(20); bRename:SetPoint("TOPLEFT", line, "BOTTOMLEFT", 0, -6); bRename:SetText("Rename")
+  local bLeave = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bLeave:SetWidth(70); bLeave:SetHeight(20); bLeave:SetPoint("LEFT", bRename, "RIGHT", 6, 0); bLeave:SetText("Leave")
+  local leaderCB = CreateFrame("CheckButton", nil, frame, "UICheckButtonTemplate")
+  leaderCB:SetWidth(20); leaderCB:SetHeight(20); leaderCB:SetPoint("LEFT", bLeave, "RIGHT", 8, 0)
+  leaderCB.text = leaderCB:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+  leaderCB.text:SetPoint("LEFT", leaderCB, "RIGHT", 2, 0)
+  leaderCB.text:SetText("Group Leader")
+
+  local bSettings = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bSettings:SetWidth(90); bSettings:SetHeight(20); bSettings:SetPoint("TOPLEFT", bRename, "BOTTOMLEFT", 0, -4); bSettings:SetText("Settings")
+
+  local bYes = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bYes:SetWidth(70); bYes:SetHeight(20); bYes:SetPoint("TOPLEFT", line, "BOTTOMLEFT", 0, -6); bYes:SetText("Yes")
+  local bBackC = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bBackC:SetWidth(70); bBackC:SetHeight(20); bBackC:SetPoint("LEFT", bYes, "RIGHT", 6, 0); bBackC:SetText("Back")
+
+  local groupDD = CreateFrame("Frame", nil, frame, "UIDropDownMenuTemplate")
+  groupDD:SetPoint("TOPLEFT", line, "BOTTOMLEFT", -16, -4); UIDropDownMenu_SetWidth(120, groupDD)
+  local catDD = CreateFrame("Frame", nil, frame, "UIDropDownMenuTemplate")
+  catDD:SetPoint("LEFT", groupDD, "RIGHT", 6, 0); UIDropDownMenu_SetWidth(120, catDD)
+  local bBackD = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bBackD:SetWidth(60); bBackD:SetHeight(20); bBackD:SetPoint("LEFT", catDD, "RIGHT", -4, 2); bBackD:SetText("Back")
+
+  frame.dgGrowthLabel = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+  frame.dgGrowthLabel:SetPoint("TOPLEFT", line, "BOTTOMLEFT", 0, -6)
+  frame.dgGrowthLabel:SetText("Group expand direction:")
+  local growthDD = frame.growthDD
+  if growthDD then growthDD:ClearAllPoints(); growthDD:SetPoint("LEFT", frame.dgGrowthLabel, "RIGHT", -6, -2) end
+  local numLbl = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+  numLbl:SetPoint("TOPLEFT", frame.dgGrowthLabel, "BOTTOMLEFT", 0, -10); numLbl:SetText("# of icons visible:")
+  local numDD = frame.numAurasDD
+  if numDD then numDD:ClearAllPoints(); numDD:SetPoint("LEFT", numLbl, "RIGHT", -6, -2) end
+  local spaceLbl = frame.spacingLabel
+  if spaceLbl then spaceLbl:ClearAllPoints(); spaceLbl:SetPoint("TOPLEFT", numLbl, "BOTTOMLEFT", 0, -12); spaceLbl:SetText("Spacing between icons:") end
+  local spaceS = frame.spacingSlider
+  if spaceS then spaceS:ClearAllPoints(); spaceS:SetPoint("LEFT", spaceLbl, "RIGHT", 10, 0) end
+  local spaceE = frame.spacingEdit
+  if spaceE then spaceE:ClearAllPoints(); spaceE:SetPoint("LEFT", spaceS, "RIGHT", 8, 0) end
+  local bBackSettings = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+  bBackSettings:SetWidth(60); bBackSettings:SetHeight(20); bBackSettings:SetPoint("LEFT", spaceE, "RIGHT", 8, 0); bBackSettings:SetText("Back")
+
+  local all = { bNew,bExisting,bGroup,bCat,bBackA,nameLbl,nameIn,bAdd,bBackB,bRename,bLeave,leaderCB,bSettings,bYes,bBackC,groupDD,catDD,bBackD,frame.dgGrowthLabel,numLbl,bBackSettings }
+  local function HideAll() local i=1 while i<=table.getn(all) do all[i]:Hide(); i=i+1 end if growthDD then growthDD:Hide() end if numDD then numDD:Hide() end if spaceLbl then spaceLbl:Hide() end if spaceS then spaceS:Hide() end if spaceE then spaceE:Hide() end end
+
+  local function SetAddState()
+    local txt = _TrimName(nameIn:GetText() or "")
+    local list = _BuildNames(state.mode)
+    local dup = false
+    local i = 1
+    while i <= table.getn(list) do if string.upper(list[i]) == string.upper(txt) and list[i] ~= state._renameFrom then dup = true; break end i=i+1 end
+    if txt == "" or dup then bAdd:Disable() else bAdd:Enable() end
+  end
+
+  local function Join(kind, name)
+    local d = Ensure(); if not d then return end
+    if kind == "group" then
+      d.category = nil
+      d.group = name
+      d.isLeader = false
+      _EnsureUniqueLeader(name)
+      local hasLeader = false
+      for k2, s in pairs(_DA_DB().spells) do if s.group == name and s.isLeader then hasLeader = true; break end end
+      if not hasLeader then d.isLeader = true end
+      state.step = "ingroup"
+    else
+      d.group = nil
+      d.isLeader = false
+      d.category = name
+      local db = _DA_DB()
+      local found = false
+      local i=1 while i<=table.getn(db.categories) do if db.categories[i]==name then found=true break end i=i+1 end
+      if not found then table.insert(db.categories, name) end
+      state.step = "incategory"
+    end
+    RefreshAll()
+  end
+
+  local function LeaveCurrent()
+    local d = Ensure(); if not d then return end
+    if state.mode == "category" then
+      local old = d.category
+      d.category = nil
+      _CleanupCategoryIfEmpty(old)
+      state.step = "pick"
+    else
+      local old = d.group
+      local wasLeader = d.isLeader
+      d.group = nil; d.isLeader = false
+      if wasLeader and old then _EnsureUniqueLeader(old) end
+      _CleanupGroupIfEmpty(old)
+      state.step = "pick"
+    end
+    RefreshAll()
+  end
+
+  local function RenameAll(newName)
+    local d = Ensure(); if not d then return end
+    local from = state._renameFrom
+    if not from or from == "" then return end
+    if state.mode == "category" then
+      for _, s in pairs(_DA_DB().spells) do if s.category == from then s.category = newName end end
+      local db = _DA_DB(); local found=false; local i=1 while i<=table.getn(db.categories) do if db.categories[i]==from then db.categories[i]=newName; found=true end i=i+1 end
+      if not found then table.insert(db.categories, newName) end
+      _CleanupCategoryIfEmpty(from)
+      d.category = newName
+      state.step = "incategory"
+    else
+      for _, s in pairs(_DA_DB().spells) do if s.group == from then s.group = newName end end
+      local db = _DA_DB()
+      if db.groupSort and db.groupSort[from] ~= nil then db.groupSort[newName] = db.groupSort[from]; db.groupSort[from] = nil end
+      if db.groupFixed and db.groupFixed[from] ~= nil then db.groupFixed[newName] = db.groupFixed[from]; db.groupFixed[from] = nil end
+      d.group = newName
+      _CleanupGroupIfEmpty(from)
+      _EnsureUniqueLeader(newName)
+      state.step = "ingroup"
+    end
+    RefreshAll()
+  end
+
+  local function Refresh()
+    local d = Ensure(); if not d then return end
+    HideAll()
+    state.mode = nil
+    if d.group and d.group ~= "" then state.mode = "group"; state.step = state.step == "settings" and "settings" or "ingroup"
+    elseif d.category and d.category ~= "" then state.mode = "category"; state.step = "incategory"
+    elseif state.step ~= "newkind" and state.step ~= "newname" and state.step ~= "existing" then state.step = "pick" end
+
+    if state.step == "pick" then
+      line:SetText("If you want to Group or Categorize this icon, select an option below:")
+      bNew:Show(); bExisting:Show()
+    elseif state.step == "newkind" then
+      line:SetText("Would you like to place the icon in a new Group or Category?")
+      bGroup:Show(); bCat:Show(); bBackA:Show()
+    elseif state.step == "newname" then
+      line:SetText("Please select a unique name below:")
+      nameLbl:SetText(state.mode == "group" and "New Group name:" or "New Category name:")
+      nameLbl:Show(); nameIn:Show(); bAdd:Show(); bBackB:Show(); SetAddState()
+    elseif state.step == "incategory" then
+      line:SetText("Included in Category: " .. tostring(d.category or ""))
+      bRename:Show(); bLeave:Show()
+    elseif state.step == "ingroup" then
+      line:SetText("Included in Group: " .. tostring(d.group or ""))
+      bRename:Show(); bLeave:Show(); leaderCB:Show(); bSettings:Show()
+      leaderCB:SetChecked(d.isLeader and true or false)
+      if d.isLeader then leaderCB:Disable(); bSettings:Enable() else leaderCB:Enable(); bSettings:Disable() end
+    elseif state.step == "confirmleave" then
+      if state.mode == "group" then line:SetText("Are you sure you want the icon to leave the group?") else line:SetText("Are you sure you want the icon to leave the category?") end
+      bYes:Show(); bBackC:Show()
+    elseif state.step == "existing" then
+      line:SetText("Select what existing Group or Category you want to place the icon in:")
+      groupDD:Show(); catDD:Show(); bBackD:Show()
+      UIDropDownMenu_Initialize(groupDD, function()
+        local arr = _BuildNames("group")
+        local i=1 while i<=table.getn(arr) do local n=arr[i]; local info=UIDropDownMenu_CreateInfo(); info.text=n; info.value=n; info.func=function() Join("group", n) end; UIDropDownMenu_AddButton(info); i=i+1 end
+      end)
+      UIDropDownMenu_SetText("Group", groupDD)
+      UIDropDownMenu_Initialize(catDD, function()
+        local arr = _BuildNames("category")
+        local i=1 while i<=table.getn(arr) do local n=arr[i]; local info=UIDropDownMenu_CreateInfo(); info.text=n; info.value=n; info.func=function() Join("category", n) end; UIDropDownMenu_AddButton(info); i=i+1 end
+      end)
+      UIDropDownMenu_SetText("Category", catDD)
+    elseif state.step == "settings" then
+      line:SetText("Group settings")
+      frame.dgGrowthLabel:Show(); if growthDD then growthDD:Show() end
+      numLbl:Show(); if numDD then numDD:Show() end
+      if spaceLbl then spaceLbl:Show() end; if spaceS then spaceS:Show() end; if spaceE then spaceE:Show() end
+      if growthDD and frame.InitGrowthDropdown then
+        frame.InitGrowthDropdown(growthDD, d)
+        UIDropDownMenu_SetText(d.growth or "Horizontal Right", growthDD)
+      end
+      if numDD and frame.InitNumAurasDropdown then
+        frame.InitNumAurasDropdown(numDD, d)
+        UIDropDownMenu_SetText(tostring(d.numAuras or 5), numDD)
+      end
+      local settings = (DoiteAurasDB and DoiteAurasDB.settings)
+      local s = d.spacing
+      if not s then s = (settings and settings.spacing) or 8 end
+      if spaceS then spaceS:SetValue(s) end
+      if spaceE then spaceE:SetText(tostring(s)) end
+      bBackSettings:Show()
+    end
+  end
+
+  bNew:SetScript("OnClick", function() state.step = "newkind"; Refresh() end)
+  bExisting:SetScript("OnClick", function() state.step = "existing"; Refresh() end)
+  bGroup:SetScript("OnClick", function() state.mode = "group"; state.step = "newname"; state.rename=false; state._renameFrom=nil; nameIn:SetText(""); Refresh() end)
+  bCat:SetScript("OnClick", function() state.mode = "category"; state.step = "newname"; state.rename=false; state._renameFrom=nil; nameIn:SetText(""); Refresh() end)
+  bBackA:SetScript("OnClick", function() state.step = "pick"; Refresh() end)
+  bBackB:SetScript("OnClick", function() if state.rename then state.step = (state.mode == "group") and "ingroup" or "incategory" else state.step = "newkind" end; Refresh() end)
+  bRename:SetScript("OnClick", function() local d=Ensure(); state.rename=true; state._renameFrom=(state.mode=="group") and d.group or d.category; nameIn:SetText(state._renameFrom or ""); state.step="newname"; Refresh() end)
+  bLeave:SetScript("OnClick", function() state.step = "confirmleave"; Refresh() end)
+  bYes:SetScript("OnClick", function() LeaveCurrent(); Refresh() end)
+  bBackC:SetScript("OnClick", function() state.step = (state.mode == "group") and "ingroup" or "incategory"; Refresh() end)
+  bBackD:SetScript("OnClick", function() state.step = "pick"; Refresh() end)
+  bSettings:SetScript("OnClick", function() state.step = "settings"; Refresh() end)
+  bBackSettings:SetScript("OnClick", function() state.step = "ingroup"; Refresh() end)
+
+  leaderCB:SetScript("OnClick", function(self)
+    local d = Ensure(); if not d or not d.group then self:SetChecked(false); return end
+    if self:GetChecked() then
+      for k, s in pairs(_DA_DB().spells) do if s.group == d.group and k ~= state.key then s.isLeader = false end end
+      d.isLeader = true
+      self:SetChecked(true); self:Disable()
+      bSettings:Enable()
+      RefreshAll()
+    else
+      self:SetChecked(d.isLeader and true or false)
+    end
+  end)
+
+  nameIn:SetScript("OnTextChanged", function() SetAddState() end)
+  bAdd:SetScript("OnClick", function()
+    local picked = _TrimName(nameIn:GetText() or "")
+    if picked == "" then return end
+    if state.rename then RenameAll(picked) else Join(state.mode, picked) end
+    nameIn:SetText("")
+    Refresh()
+  end)
+
+  frame.DoiteGroupUIRefresh = function(_, key)
+    state.key = key
+    Refresh()
+  end
+  frame.DoiteGroupUIIsLeaderOrFree = function()
+    local d = Ensure()
+    if not d then return true end
+    if not d.group or d.group == "" then return true end
+    return d.isLeader == true
+  end
+end


### PR DESCRIPTION
### Motivation
- Replace the old fixed "Group 1-10" selection model with a dynamic naming workflow so users can create, rename and manage arbitrary Groups and Categories while preserving existing DB fields `group` and `isLeader`.
- Move the interactive group/category creation and management UI out of the large `DoiteEdit` frame into `DoiteGroup` to centralize dynamic group logic and reduce clutter in the edit frame.
- Preserve current runtime/grouping behaviors (leader semantics, leader-driven layout, group settings) while improving and unifying the visual and interaction flow for creating/joining/renaming/leaving groups and categories.

### Description
- Added a step-driven editor and DB helpers to `Modules/DoiteGroup.lua`, including `_DA_DB`, `_BuildNames`, `_EnsureUniqueLeader`, `_CleanupCategoryIfEmpty`, `_CleanupGroupIfEmpty`, and `DoiteGroup.AttachEditGroupUI` to handle New/Existing flows, unique-name validation, rename propagation, leave confirmation, and leader transfer rules.
- Implemented an in-frame step UI in `DoiteGroup.AttachEditGroupUI` providing: `New`/`Existing` entry points, `Group`/`Category` creation with an input box, rename flow that updates all icons, leave confirmation that cleans empty buckets, and a `Settings` step exposing growth/numAuras/spacing controls for group leaders.
- Updated `Modules/DoiteEdit.lua` to remove the old `Group 1-10` dropdown code and `BuildGroupLeaders` helper, hide the legacy category row in the conditions area, and delegate the top-of-frame group/category UI to `DoiteGroup.AttachEditGroupUI` while exposing `InitGrowthDropdown` and `InitNumAurasDropdown` so the group settings step can reuse existing leader-only controls.
- Kept the DB shape and runtime behavior intact: icons still store `group` and `isLeader`, leader-only layout controls remain leader-gated, and group metadata (like `groupSort` / `groupFixed` / bucket keys) are cleaned when groups are removed.

### Testing
- Ran repository inspections using `rg`/`sed`/`nl` to verify inserted functions, call sites and that `DoiteEdit` now delegates to `DoiteGroup.AttachEditGroupUI`, and these file-level checks succeeded.
- Attempted to perform a Lua module load check via `lua -e 'assert(loadfile("Modules/DoiteGroup.lua")); assert(loadfile("Modules/DoiteEdit.lua"))'`, but the environment did not provide a usable `lua` binary so a runtime load check could not be executed (tooling unavailable).
- Attempted syntax checks with `luac`/`luac5.1` and a `luac -p` style check, but `luac` was not available in this environment so syntax verification could not be performed.
- Performed repository diff/stats verification (`git diff --stat`) to confirm the intended edits to `Modules/DoiteGroup.lua` and `Modules/DoiteEdit.lua` were applied, and these inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a954569c54832ab7967b53fe357420)