### PR TITLE
Adjust list row height when rename controls are hidden

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -3143,7 +3143,7 @@ local function RefreshList()
                 local btn = spellButtons[key]
                 if not btn then
                     btn = CreateFrame("Frame", nil, listContent)
-                    btn:SetWidth(320); btn:SetHeight(78)
+                    btn:SetWidth(320); btn:SetHeight(53)
 
                     btn.fontString = btn:CreateFontString(nil, "OVERLAY", "GameFontNormal")
                     btn.fontString:SetPoint("TOPLEFT", btn, "TOPLEFT", 15, -2)
@@ -3406,6 +3406,7 @@ local function RefreshList()
                     btn.renameAddBtn:Show()
                     btn.renameResetBtn:Show()
                     btn.renameBackBtn:Show()
+                    btn:SetHeight(78)
                     local currentShown = data.shownName or data.displayName or data.name or ""
                     if btn.renameInput:GetText() ~= currentShown and not btn.renameInput:HasFocus() then
                         btn.renameInput:SetText(currentShown)
@@ -3416,6 +3417,7 @@ local function RefreshList()
                     btn.renameAddBtn:Hide()
                     btn.renameResetBtn:Hide()
                     btn.renameBackBtn:Hide()
+                    btn:SetHeight(53)
                 end
 
                 -- Position row (ClearAllPoints is important when reusing frames)


### PR DESCRIPTION
### Motivation
- The separator between icons in the list could be misaligned when the rename-controls row was hidden because every row was initialized at the taller height, so compact rows needed to be smaller to keep separators positioned correctly.

### Description
- Change default per-row height in `DoiteAuras.lua` from `78` to `53`, and explicitly set a row to `78` when `renameState.key == key` and to `53` when the rename controls are hidden so separators stay consistent.

### Testing
- Attempted a Lua syntax check with `luac -p DoiteAuras.lua` but `luac` is not installed in this environment so the syntax check could not be performed; the file diff was inspected and a Git commit was created to record the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad71aad90c832a9388a08e5e6fedf6)