### PR TITLE
Add Fade visual effect (checkbox + slider) across DoiteEdit and apply alpha in DoiteConditions

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -4889,10 +4889,11 @@ local _DA_SWIFTMEND_NEEDS = { "Rejuvenation", "Regrowth" }
 
 local function _EvaluateVfxConditions(data)
   if not data or not data.conditions then
-    return false, false
+    return false, false, nil
   end
 
   local glowOut, greyOut = false, false
+  local fadeOut = nil
 
   local types = { "ability", "aura", "item" }
   local tIdx, typeKey
@@ -4905,12 +4906,20 @@ local function _EvaluateVfxConditions(data)
         if _AuraConditions_CheckEntry(entry) then
           if entry.glow then glowOut = true end
           if entry.grey then greyOut = true end
+          if entry.fade then
+            local fa = tonumber(entry.fadeAlpha) or 0.5
+            if fa < 0.1 then fa = 0.1 end
+            if fa > 1 then fa = 1 end
+            if fadeOut == nil or fa < fadeOut then
+              fadeOut = fa
+            end
+          end
         end
       end
     end
   end
 
-  return glowOut, greyOut
+  return glowOut, greyOut, fadeOut
 end
 
 -- ============================================================
@@ -4938,7 +4947,7 @@ local function CheckAbilityConditions(data)
   if _IsKeyUnderEdit(data.key) then
     local glow = (c.glow and true) or false
     local grey = (c.greyscale and true) or false
-    return true, glow, grey
+    return true, glow, grey, nil
   end
 
   -- "show" now represents ALL NON-MODE conditions.
@@ -5299,16 +5308,27 @@ local function CheckAbilityConditions(data)
       (data._daSoundGate and c.soundOffCDEnabled == true),
       c.soundOffCD)
 
-  local vGlow, vGrey = _EvaluateVfxConditions(data)
+  local vGlow, vGrey, vFade = _EvaluateVfxConditions(data)
   local glow = (c.glow or vGlow) and true or false
   local grey = (c.greyscale or vGrey) and true or false
+  local fadeAlpha = nil
+  if c.fade then
+    fadeAlpha = tonumber(c.fadeAlpha) or 0.5
+  elseif vFade ~= nil then
+    fadeAlpha = tonumber(vFade)
+  end
+  if fadeAlpha ~= nil then
+    if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
+    if fadeAlpha > 1 then fadeAlpha = 1 end
+  end
 
   if not show then
     glow = false
     grey = false
+    fadeAlpha = nil
   end
 
-  return show, glow, grey
+  return show, glow, grey, fadeAlpha
 end
 
 -- ============================================================
@@ -5323,7 +5343,7 @@ local function CheckItemConditions(data)
   if _IsKeyUnderEdit(data.key) then
     local glow = (c.glow and true) or false
     local grey = (c.greyscale and true) or false
-    return true, glow, grey
+    return true, glow, grey, nil
   end
 
   local show = true
@@ -5344,7 +5364,7 @@ local function CheckItemConditions(data)
     data._daSoundGate = false
     local glow = c.glow and true or false
     local grey = c.greyscale and true or false
-    return false, glow, grey
+    return false, glow, grey, nil
   end
 
   if state.modeMatches == false then
@@ -5559,16 +5579,27 @@ local function CheckItemConditions(data)
       (data._daSoundGate and c.soundOffCDEnabled == true),
       c.soundOffCD)
 
-  local vGlow, vGrey = _EvaluateVfxConditions(data)
+  local vGlow, vGrey, vFade = _EvaluateVfxConditions(data)
   local glow = (c.glow or vGlow) and true or false
   local grey = (c.greyscale or vGrey) and true or false
+  local fadeAlpha = nil
+  if c.fade then
+    fadeAlpha = tonumber(c.fadeAlpha) or 0.5
+  elseif vFade ~= nil then
+    fadeAlpha = tonumber(vFade)
+  end
+  if fadeAlpha ~= nil then
+    if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
+    if fadeAlpha > 1 then fadeAlpha = 1 end
+  end
 
   if not show then
     glow = false
     grey = false
+    fadeAlpha = nil
   end
 
-  return show, glow, grey
+  return show, glow, grey, fadeAlpha
 end
 
 -- ============================================================
@@ -5583,7 +5614,7 @@ local function CheckAuraConditions(data)
   if _IsKeyUnderEdit(data.key) then
     local glow = (c.glow and true) or false
     local grey = (c.greyscale and true) or false
-    return true, glow, grey
+    return true, glow, grey, nil
   end
 
   local name = data.displayName or data.name
@@ -6020,16 +6051,27 @@ local function CheckAuraConditions(data)
     end
   end
 
-  local vGlow, vGrey = _EvaluateVfxConditions(data)
+  local vGlow, vGrey, vFade = _EvaluateVfxConditions(data)
   local glow = (c.glow or vGlow) and true or false
   local grey = (c.greyscale or vGrey) and true or false
+  local fadeAlpha = nil
+  if c.fade then
+    fadeAlpha = tonumber(c.fadeAlpha) or 0.5
+  elseif vFade ~= nil then
+    fadeAlpha = tonumber(vFade)
+  end
+  if fadeAlpha ~= nil then
+    if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
+    if fadeAlpha > 1 then fadeAlpha = 1 end
+  end
 
   if not show then
     glow = false
     grey = false
+    fadeAlpha = nil
   end
 
-  return show, glow, grey
+  return show, glow, grey, fadeAlpha
 end
 
 ---------------------------------------------------------------
@@ -6056,17 +6098,17 @@ function DoiteConditions:EvaluateAll()
         data.key = key
 
         if data.type == "Ability" or data.type == "Item" then
-          local show, glow, grey
+          local show, glow, grey, fadeAlpha
           if data.type == "Ability" then
-            show, glow, grey = CheckAbilityConditions(data)
+            show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
           else
-            show, glow, grey = CheckItemConditions(data)
+            show, glow, grey, fadeAlpha = CheckItemConditions(data)
           end
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
 
         elseif data.type == "Buff" or data.type == "Debuff" then
-          local show, glow, grey = CheckAuraConditions(data)
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
         end
       end
     end
@@ -6082,17 +6124,17 @@ function DoiteConditions:EvaluateAll()
           data.key = key
 
           if data.type == "Ability" or data.type == "Item" then
-            local show, glow, grey
+            local show, glow, grey, fadeAlpha
             if data.type == "Ability" then
-              show, glow, grey = CheckAbilityConditions(data)
+              show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
             else
-              show, glow, grey = CheckItemConditions(data)
+              show, glow, grey, fadeAlpha = CheckItemConditions(data)
             end
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
 
           elseif data.type == "Buff" or data.type == "Debuff" then
-            local show, glow, grey = CheckAuraConditions(data)
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
           end
         end
       end
@@ -6628,7 +6670,7 @@ end
 ---------------------------------------------------------------
 -- Apply visuals to icons
 ---------------------------------------------------------------
-function DoiteConditions:ApplyVisuals(key, show, glow, grey)
+function DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
   local frame = _GetIconFrame(key)
   if not frame then
     -- If icons rebuilt, forget any stale cached ref for this key and retry.
@@ -6799,6 +6841,8 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
     frame._daUseGlow = useGlow and true or false
     frame._daUseGlow = useGlow and true or false
     frame._daUseGreyscale = useGrey and true or false
+    frame._daUseFade = (fadeAlpha ~= nil) and true or false
+    frame._daFadeAlpha = fadeAlpha
     -- Sync with DoiteAuras.lua expectation
     frame._daGreyscale = frame._daUseGreyscale
   end
@@ -6862,7 +6906,11 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
             if not (isGrouped and not isLeader) then
               frame:ClearAllPoints()
               frame:SetPoint("CENTER", UIParent, "CENTER", baseX, baseY)
-              frame:SetAlpha((dataTbl and dataTbl.alpha) or 1)
+              local baseAlpha = (dataTbl and dataTbl.alpha) or 1
+              if frame._daUseFade and frame._daFadeAlpha then
+                baseAlpha = baseAlpha * frame._daFadeAlpha
+              end
+              frame:SetAlpha(baseAlpha)
             else
               -- Followers:
               -- Only re-anchor having a computed group position for this key.
@@ -6871,7 +6919,11 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
                 frame:SetPoint("CENTER", UIParent, "CENTER", baseX, baseY)
               end
               -- If !hasGroupPos: do not touch points this tick; avoid snapping back to original x/y.
-              frame:SetAlpha((dataTbl and dataTbl.alpha) or 1)
+              local baseAlpha = (dataTbl and dataTbl.alpha) or 1
+              if frame._daUseFade and frame._daFadeAlpha then
+                baseAlpha = baseAlpha * frame._daFadeAlpha
+              end
+              frame:SetAlpha(baseAlpha)
             end
           end
       end
@@ -6900,7 +6952,11 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
         frame:Show()
 
         if not slideActive then
-          frame:SetAlpha(1)
+          local baseAlpha = (dataTbl and dataTbl.alpha) or 1
+          if frame._daUseFade and frame._daFadeAlpha then
+            baseAlpha = baseAlpha * frame._daFadeAlpha
+          end
+          frame:SetAlpha(baseAlpha)
         end
       else
         frame:Hide()
@@ -7004,13 +7060,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
           data = key and live[key]
           if data and (data.type == "Ability" or data.type == "Item") then
             data.key = key
-            local show, glow, grey
+            local show, glow, grey, fadeAlpha
             if data.type == "Ability" then
-              show, glow, grey = CheckAbilityConditions(data)
+              show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
             else
-              show, glow, grey = CheckItemConditions(data)
+              show, glow, grey, fadeAlpha = CheckItemConditions(data)
             end
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
           end
           i = i + 1
         end
@@ -7028,13 +7084,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
             data = edit[key]
             if data and (data.type == "Ability" or data.type == "Item") then
               data.key = key
-              local show, glow, grey
+              local show, glow, grey, fadeAlpha
               if data.type == "Ability" then
-                show, glow, grey = CheckAbilityConditions(data)
+                show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
               else
-                show, glow, grey = CheckItemConditions(data)
+                show, glow, grey, fadeAlpha = CheckItemConditions(data)
               end
-              DoiteConditions:ApplyVisuals(key, show, glow, grey)
+              DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
             end
           end
           i = i + 1
@@ -7064,13 +7120,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
 
         if wantsLogic or wantsTime then
           data.key = key
-          local show, glow, grey
+          local show, glow, grey, fadeAlpha
           if data.type == "Ability" then
-            show, glow, grey = CheckAbilityConditions(data)
+            show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
           else
-            show, glow, grey = CheckItemConditions(data)
+            show, glow, grey, fadeAlpha = CheckItemConditions(data)
           end
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
         end
       end
     end
@@ -7094,13 +7150,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
 
           if wantsLogic or wantsTime then
             data.key = key
-            local show, glow, grey
+            local show, glow, grey, fadeAlpha
             if data.type == "Ability" then
-              show, glow, grey = CheckAbilityConditions(data)
+              show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
             else
-              show, glow, grey = CheckItemConditions(data)
+              show, glow, grey, fadeAlpha = CheckItemConditions(data)
             end
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
           end
         end
       end
@@ -7178,7 +7234,7 @@ local function _DoiteCustomEvaluateOne(key, data)
     data._daCustomHideBG = false
     data._daCustomRemaining = nil
     data._daCustomStacks = nil
-    DoiteConditions:ApplyVisuals(key, false, false, false)
+    DoiteConditions:ApplyVisuals(key, false, false, false, nil)
     return true
   end
 
@@ -7196,7 +7252,7 @@ local function _DoiteCustomEvaluateOne(key, data)
     data._daCustomHideBG = false
     data._daCustomRemaining = nil
     data._daCustomStacks = nil
-    DoiteConditions:ApplyVisuals(key, false, false, false)
+    DoiteConditions:ApplyVisuals(key, false, false, false, nil)
     return true
   end
 
@@ -7207,7 +7263,7 @@ local function _DoiteCustomEvaluateOne(key, data)
   data._daCustomRemaining = (type(remaining) == "number") and remaining or nil
   data._daCustomStacks = (type(stacks) == "number") and stacks or nil
 
-  DoiteConditions:ApplyVisuals(key, data._daCustomShow, false, false)
+  DoiteConditions:ApplyVisuals(key, data._daCustomShow, false, false, nil)
   return true
 end
 
@@ -7266,8 +7322,8 @@ function DoiteConditions:EvaluateAuras()
       elseif data.type == "Buff" or data.type == "Debuff" then
         data.key = key
 
-        local show, glow, grey = CheckAuraConditions(data)
-        DoiteConditions:ApplyVisuals(key, show, glow, grey)
+        local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+        DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
       end
     end
   end
@@ -7282,8 +7338,8 @@ function DoiteConditions:EvaluateAuras()
         elseif data.type == "Buff" or data.type == "Debuff" then
           data.key = key
 
-          local show, glow, grey = CheckAuraConditions(data)
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
         end
       end
     end

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -1579,6 +1579,22 @@ local function CreateConditionsUI()
     return eb
   end
 
+  local function MakeMiniFadeSlider(name, x, y)
+    local parent = _Parent()
+    local s = CreateFrame("Slider", name, parent, "OptionsSliderTemplate")
+    s:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+    s:SetWidth(70)
+    s:SetHeight(12)
+    s:SetMinMaxValues(10, 100)
+    s:SetValueStep(5)
+    s:SetObeyStepOnDrag(true)
+
+    if _G[name .. "Low"] then _G[name .. "Low"]:SetText("") end
+    if _G[name .. "High"] then _G[name .. "High"]:SetText("") end
+    if _G[name .. "Text"] then _G[name .. "Text"]:SetText("") end
+    return s
+  end
+
   -- renders a small bold white title with a "split" separator line that does not pass under the text
   local function MakeSeparatorRow(parent, y, title, drawLine)
     drawLine = (drawLine ~= false)
@@ -1801,6 +1817,8 @@ local function CreateConditionsUI()
 
   condFrame.cond_ability_glow = MakeCheck("DoiteCond_Ability_Glow", "Glow", 0, row5_y)
   condFrame.cond_ability_greyscale = MakeCheck("DoiteCond_Ability_Greyscale", "Grey", 70, row5_y)
+  condFrame.cond_ability_fade = MakeCheck("DoiteCond_Ability_Fade", "Fade", 140, row5_y)
+  condFrame.cond_ability_fade_slider = MakeMiniFadeSlider("DoiteCond_Ability_FadeSlider", 190, row5_y - 2)
   condFrame.cond_ability_slider_glow = MakeCheck("DoiteCond_Ability_SliderGlow", "CD Glow", 140, row5_y)
   condFrame.cond_ability_slider_grey = MakeCheck("DoiteCond_Ability_SliderGrey", "CD Grey", 220, row5_y)
   SetSeparator("ability", 5, "VISUAL EFFECTS", true, true)
@@ -2023,6 +2041,8 @@ local function CreateConditionsUI()
 
   condFrame.cond_aura_glow = MakeCheck("DoiteCond_Aura_Glow", "Glow", 0, row5_y)
   condFrame.cond_aura_greyscale = MakeCheck("DoiteCond_Aura_Greyscale", "Grey", 70, row5_y)
+  condFrame.cond_aura_fade = MakeCheck("DoiteCond_Aura_Fade", "Fade", 140, row5_y)
+  condFrame.cond_aura_fade_slider = MakeMiniFadeSlider("DoiteCond_Aura_FadeSlider", 190, row5_y - 2)
   SetSeparator("aura", 5, "VISUAL EFFECTS", true, true)
 
   -- AURA ROW: TARGET DISTANCE & TYPE
@@ -2291,6 +2311,8 @@ local function CreateConditionsUI()
   -- VISUAL EFFECTS
   condFrame.cond_item_glow = MakeCheck("DoiteCond_Item_Glow", "Glow", 0, row7_y)
   condFrame.cond_item_greyscale = MakeCheck("DoiteCond_Item_Greyscale", "Grey", 70, row7_y)
+  condFrame.cond_item_fade = MakeCheck("DoiteCond_Item_Fade", "Fade", 140, row7_y)
+  condFrame.cond_item_fade_slider = MakeMiniFadeSlider("DoiteCond_Item_FadeSlider", 190, row7_y - 2)
   SetSeparator("item", 7, "VISUAL EFFECTS", true, true)
 
   -- ITEM ROW: TARGET DISTANCE & TYPE
@@ -3676,6 +3698,35 @@ function UpdateItemStacksForMissing()
     SafeEvaluate()
   end)
 
+  condFrame.cond_aura_fade:SetScript("OnClick", function()
+    if not currentKey then
+      this:SetChecked(false)
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.aura = d.conditions.aura or {}
+    d.conditions.aura.fade = this:GetChecked() and true or false
+    if d.conditions.aura.fade and not d.conditions.aura.fadeAlpha then
+      d.conditions.aura.fadeAlpha = 0.5
+    end
+    UpdateCondFrameForKey(currentKey)
+    SafeRefresh()
+    SafeEvaluate()
+  end)
+
+  condFrame.cond_aura_fade_slider:SetScript("OnValueChanged", function()
+    if not currentKey then
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.aura = d.conditions.aura or {}
+    d.conditions.aura.fadeAlpha = ((this:GetValue() or 100) / 100)
+    SafeRefresh()
+    SafeEvaluate()
+  end)
+
   -- === Combo points enable toggles ===
   condFrame.cond_ability_cp_cb:SetScript("OnClick", function()
     if not currentKey then
@@ -4000,6 +4051,33 @@ function UpdateItemStacksForMissing()
     SafeRefresh();
     SafeEvaluate()
   end)
+  condFrame.cond_item_fade:SetScript("OnClick", function()
+    if not currentKey then
+      this:SetChecked(false)
+      return
+    end
+    local d = EnsureDBEntry(currentKey);
+    d.conditions.item = d.conditions.item or {}
+    d.conditions.item.fade = this:GetChecked() and true or false
+    if d.conditions.item.fade and not d.conditions.item.fadeAlpha then
+      d.conditions.item.fadeAlpha = 0.5
+    end
+    UpdateCondFrameForKey(currentKey);
+    SafeRefresh();
+    SafeEvaluate()
+  end)
+
+  condFrame.cond_item_fade_slider:SetScript("OnValueChanged", function()
+    if not currentKey then
+      return
+    end
+    local d = EnsureDBEntry(currentKey);
+    d.conditions.item = d.conditions.item or {}
+    d.conditions.item.fadeAlpha = ((this:GetValue() or 100) / 100)
+    SafeRefresh();
+    SafeEvaluate()
+  end)
+
 
   -- Item text: remaining time
   condFrame.cond_item_text_time:SetScript("OnClick", function()
@@ -4991,6 +5069,34 @@ function UpdateItemStacksForMissing()
     SafeRefresh()
     SafeEvaluate()
   end)
+  condFrame.cond_ability_fade:SetScript("OnClick", function()
+    if not currentKey then
+      this:SetChecked(false)
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.ability = d.conditions.ability or {}
+    d.conditions.ability.fade = this:GetChecked() and true or false
+    if d.conditions.ability.fade and not d.conditions.ability.fadeAlpha then
+      d.conditions.ability.fadeAlpha = 0.5
+    end
+    UpdateCondFrameForKey(currentKey)
+    SafeRefresh()
+    SafeEvaluate()
+  end)
+
+  condFrame.cond_ability_fade_slider:SetScript("OnValueChanged", function()
+    if not currentKey then
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.ability = d.conditions.ability or {}
+    d.conditions.ability.fadeAlpha = ((this:GetValue() or 100) / 100)
+    SafeRefresh()
+    SafeEvaluate()
+  end)
 
   -- Form dropdowns are initialized/updated from UpdateConditionsUI
   condFrame.cond_ability_formDD:Hide()
@@ -5021,6 +5127,8 @@ function UpdateItemStacksForMissing()
   condFrame.cond_ability_remaining_val:Hide()
   condFrame.cond_ability_remaining_val_enter:Hide()
   condFrame.cond_ability_greyscale:Hide()
+  condFrame.cond_ability_fade:Hide()
+  condFrame.cond_ability_fade_slider:Hide()
   condFrame.cond_ability_cp_cb:Hide()
   condFrame.cond_ability_cp_comp:Hide()
   condFrame.cond_ability_cp_val:Hide()
@@ -5083,6 +5191,8 @@ function UpdateItemStacksForMissing()
   condFrame.cond_aura_stacks_val:Hide()
   condFrame.cond_aura_stacks_val_enter:Hide()
   condFrame.cond_aura_greyscale:Hide()
+  condFrame.cond_aura_fade:Hide()
+  condFrame.cond_aura_fade_slider:Hide()
   condFrame.cond_aura_mine:Hide()
   if condFrame.cond_aura_others then
     condFrame.cond_aura_others:Hide()
@@ -5118,6 +5228,8 @@ function UpdateItemStacksForMissing()
   condFrame.cond_item_target_self:Hide()
   condFrame.cond_item_glow:Hide()
   condFrame.cond_item_greyscale:Hide()
+  condFrame.cond_item_fade:Hide()
+  condFrame.cond_item_fade_slider:Hide()
   condFrame.cond_item_text_time:Hide()
   condFrame.cond_item_power:Hide()
   condFrame.cond_item_power_comp:Hide()
@@ -6918,6 +7030,8 @@ do
     if row.abilityDD then row.abilityDD:Hide() end
     if row.glowCB then row.glowCB:Hide() end
     if row.greyCB then row.greyCB:Hide() end
+    if row.fadeCB then row.fadeCB:Hide() end
+    if row.fadeSlider then row.fadeSlider:Hide() end
   
     if row.stacksLabel then row.stacksLabel:Hide() end
     if row.stacksCB then row.stacksCB:Hide() end
@@ -7090,9 +7204,23 @@ do
         row.greyCB:ClearAllPoints()
         row.glowCB:SetPoint("TOPLEFT", row, "TOPLEFT", 0, -14)
         row.greyCB:SetPoint("LEFT", row.glowCB, "RIGHT", 40, 0)
+        if row.fadeCB then
+          row.fadeCB:ClearAllPoints()
+          row.fadeCB:SetPoint("LEFT", row.greyCB, "RIGHT", 40, 0)
+        end
+        if row.fadeSlider then
+          row.fadeSlider:ClearAllPoints()
+          row.fadeSlider:SetPoint("LEFT", row.fadeCB, "RIGHT", 10, 0)
+        end
   
         row.glowCB:Show()
         row.greyCB:Show()
+        if row.fadeCB then
+          row.fadeCB:Show()
+          if row.fadeCB:GetChecked() and row.fadeSlider then
+            row.fadeSlider:Show()
+          end
+        end
       end
     end
   end
@@ -7201,6 +7329,34 @@ do
         end)
       end
 
+      if row.fadeCB then
+        row.fadeCB:SetChecked(entry and entry.fade)
+        row.fadeCB:SetScript("OnClick", function()
+          local list = VfxCond_GetListForType(typeKey)
+          if list and list[row._entryIndex] then
+            list[row._entryIndex].fade = this:GetChecked() and true or nil
+            if list[row._entryIndex].fade and not list[row._entryIndex].fadeAlpha then
+              list[row._entryIndex].fadeAlpha = 0.5
+            end
+            SafeRefresh(); SafeEvaluate()
+            UpdateCondFrameForKey(currentKey)
+          end
+        end)
+      end
+      if row.fadeSlider then
+        local fadeAlpha = tonumber(entry and entry.fadeAlpha) or 0.5
+        if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
+        if fadeAlpha > 1 then fadeAlpha = 1 end
+        row.fadeSlider:SetValue(fadeAlpha * 100)
+        row.fadeSlider:SetScript("OnValueChanged", function()
+          local list = VfxCond_GetListForType(typeKey)
+          if list and list[row._entryIndex] then
+            list[row._entryIndex].fadeAlpha = ((this:GetValue() or 100) / 100)
+            SafeRefresh(); SafeEvaluate()
+          end
+        end)
+      end
+
       VfxCond_SetRowState(row, "SAVED")
       row:Show()
     end
@@ -7283,6 +7439,8 @@ do
 	  mode = mode,
 	  unit = unit,
 	  name = VfxCond_TitleCase(text),
+	  fade = nil,
+	  fadeAlpha = 0.5,
 	}
 
 	-- only for aura (buff/debuff), store optional stack settings
@@ -7460,6 +7618,19 @@ do
 
     row.glowCB = CreateMiniCheck("Glow")
     row.greyCB = CreateMiniCheck("Grey")
+    row.fadeCB = CreateMiniCheck("Fade")
+    row.fadeSlider = CreateFrame("Slider", nil, row, "OptionsSliderTemplate")
+    row.fadeSlider:SetWidth(55)
+    row.fadeSlider:SetHeight(10)
+    row.fadeSlider:SetMinMaxValues(10, 100)
+    row.fadeSlider:SetValueStep(5)
+    row.fadeSlider:SetObeyStepOnDrag(true)
+    if row.fadeSlider:GetName() then
+      local sn = row.fadeSlider:GetName()
+      if _G[sn .. "Low"] then _G[sn .. "Low"]:SetText("") end
+      if _G[sn .. "High"] then _G[sn .. "High"]:SetText("") end
+      if _G[sn .. "Text"] then _G[sn .. "Text"]:SetText("") end
+    end
 
     row.closeBtn:SetText("X")
 
@@ -7658,7 +7829,7 @@ do
       label:SetPoint("TOPLEFT", anchorFrame, "TOPLEFT", 0, -15)
       label:SetJustifyH("LEFT")
       label:SetTextColor(1, 0.82, 0)
-      label:SetText("Add visual effect conditions for glow/grey:")
+      label:SetText("Add visual effect conditions for glow/grey/fade:")
       mgr.label = label
     end
 
@@ -7779,6 +7950,7 @@ local function UpdateConditionsUI(data)
     condFrame.cond_ability_power:Show()
     condFrame.cond_ability_glow:Show()
     condFrame.cond_ability_greyscale:Show()
+    condFrame.cond_ability_fade:Show()
     condFrame.cond_ability_slider:Show()
     condFrame.cond_ability_remaining_cb:Show()
 
@@ -7950,6 +8122,16 @@ local function UpdateConditionsUI(data)
     -- glow & greyscale states
     condFrame.cond_ability_glow:SetChecked((c.ability and c.ability.glow) or false)
     condFrame.cond_ability_greyscale:SetChecked((c.ability and c.ability.greyscale) or false)
+    condFrame.cond_ability_fade:SetChecked((c.ability and c.ability.fade) or false)
+    if (c.ability and c.ability.fade) then
+      local fadeAlpha = tonumber(c.ability.fadeAlpha) or 0.5
+      if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+      condFrame.cond_ability_fade_slider:SetValue(fadeAlpha * 100)
+      condFrame.cond_ability_fade_slider:Show()
+    else
+      condFrame.cond_ability_fade_slider:Hide()
+    end
 
     -- slider vs remaining
     local slidEnabled = (c.ability and c.ability.slider) and true or false
@@ -8871,9 +9053,20 @@ local ic = c.item or {}
     -- VISUAL EFFECTS
     condFrame.cond_item_glow:Show()
     condFrame.cond_item_greyscale:Show()
+    condFrame.cond_item_fade:Show()
     condFrame.cond_item_text_time:Show()
     condFrame.cond_item_glow:SetChecked(ic.glow == true)
     condFrame.cond_item_greyscale:SetChecked(ic.greyscale == true)
+    condFrame.cond_item_fade:SetChecked(ic.fade == true)
+    if ic.fade == true then
+      local fadeAlpha = tonumber(ic.fadeAlpha) or 0.5
+      if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+      condFrame.cond_item_fade_slider:SetValue(fadeAlpha * 100)
+      condFrame.cond_item_fade_slider:Show()
+    else
+      condFrame.cond_item_fade_slider:Hide()
+    end
 
     -- Keep item text-time label constant
     do
@@ -9372,6 +9565,8 @@ local ic = c.item or {}
     _Hide(condFrame.cond_ability_target_dead)
     _Hide(condFrame.cond_ability_glow)
     _Hide(condFrame.cond_ability_greyscale)
+    _Hide(condFrame.cond_ability_fade)
+    _Hide(condFrame.cond_ability_fade_slider)
     _Hide(condFrame.cond_ability_slider)
     _Hide(condFrame.cond_ability_slider_dir)
     _Hide(condFrame.cond_ability_slider_glow)
@@ -9413,6 +9608,8 @@ local ic = c.item or {}
     _Hide(condFrame.cond_aura_target_dead)
     _Hide(condFrame.cond_aura_glow)
     _Hide(condFrame.cond_aura_greyscale)
+    _Hide(condFrame.cond_aura_fade)
+    _Hide(condFrame.cond_aura_fade_slider)
     _Hide(condFrame.cond_aura_distanceDD)
     _Hide(condFrame.cond_aura_unitTypeDD)
     _Hide(condFrame.cond_aura_power)
@@ -9470,6 +9667,8 @@ local ic = c.item or {}
     _Hide(condFrame.cond_item_target_dead)
     _Hide(condFrame.cond_item_glow)
     _Hide(condFrame.cond_item_greyscale)
+    _Hide(condFrame.cond_item_fade)
+    _Hide(condFrame.cond_item_fade_slider)
     _Hide(condFrame.cond_item_text_time)
     _Hide(condFrame.cond_item_text_time_override)
     _Hide(condFrame.cond_item_text_override_note)
@@ -9554,6 +9753,7 @@ local ic = c.item or {}
     condFrame.cond_aura_sound_onfade_dd:Show()
     condFrame.cond_aura_glow:Show()
     condFrame.cond_aura_greyscale:Show()
+    condFrame.cond_aura_fade:Show()
 
     -- mode
     local amode = (c.aura and c.aura.mode) or nil
@@ -9699,6 +9899,16 @@ local ic = c.item or {}
 
     condFrame.cond_aura_glow:SetChecked((c.aura and c.aura.glow) or false)
     condFrame.cond_aura_greyscale:SetChecked((c.aura and c.aura.greyscale) or false)
+    condFrame.cond_aura_fade:SetChecked((c.aura and c.aura.fade) or false)
+    if (c.aura and c.aura.fade) then
+      local fadeAlpha = tonumber(c.aura.fadeAlpha) or 0.5
+      if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+      condFrame.cond_aura_fade_slider:SetValue(fadeAlpha * 100)
+      condFrame.cond_aura_fade_slider:Show()
+    else
+      condFrame.cond_aura_fade_slider:Hide()
+    end
 
     local auraSoundGainOn = (c.aura and c.aura.soundOnGainEnabled) == true
     local auraSoundFadeOn = (c.aura and c.aura.soundOnFadeEnabled) == true


### PR DESCRIPTION
### Motivation

- Provide a new "Fade" visual-effect option (checkbox + small slider) alongside existing Glow/Grey controls so users can set icon transparency per-category (Ability, Buff/Debuff, Item) and per-VFX rule, combinable with existing effects.
- Ensure the fade setting persists in the same DB structure pattern as other visuals and is applied at runtime by DoiteConditions when composing final icon visuals.

### Description

- Added UI controls in `Modules/DoiteEdit.lua`: a compact `MakeMiniFadeSlider` helper, `Fade` checkboxes and small sliders for Ability, Aura and Item sections, and matching per-VFX saved-row `Fade` check + slider in the VFX rows; sliders are only shown when the corresponding Fade checkbox is active.
- Persisted new DB fields `fade` (boolean) and `fadeAlpha` (number 0.1..1) alongside existing visual flags for ability/aura/item condition buckets and VFX entries, with sensible default initialization (0.5) when enabling Fade.
- Extended VFX editor row logic so saved rows include `fade`/`fadeAlpha`, show/hide the per-row slider, and update DB + call `SafeRefresh()`/`SafeEvaluate()` on changes.
- Extended VFX evaluation and core condition evaluators in `Modules/DoiteConditions.lua`: `_EvaluateVfxConditions` now returns a computed fade alpha (nullable), `CheckAbilityConditions` / `CheckItemConditions` / `CheckAuraConditions` return `fadeAlpha` along with show/glow/grey, and `DoiteConditions:ApplyVisuals` accepts `fadeAlpha` and multiplies it with the icon base alpha when applying visibility/alpha (including during show/slide handling) while preserving existing glow/grey/slider behavior.
- Updated VFX labels, show/hide logic, and wired slider callbacks to update DB and trigger refresh/evaluation so the slider is visible only when relevant and the setting is stored like other visual flags.

### Testing

- Inspected and validated diffs and inserted logic by grepping and printing (`rg`, `nl`, `git diff`, `git show --stat`) to confirm additions across `Modules/DoiteEdit.lua` and `Modules/DoiteConditions.lua` and commit the change; commit succeeded.
- Attempted to run a Lua module load smoke test with `lua -e "assert(loadfile('Modules/DoiteEdit.lua')) ; assert(loadfile('Modules/DoiteConditions.lua')) ; print('ok')"` but `lua` is not installed in this environment, so runtime load could not be executed here.
- Attempted linting with `luacheck` but the tool is not available in the container; however, thorough static inspections (`rg`, `sed`) were used to verify callsites, signatures, and that `ApplyVisuals` call paths propagate `fadeAlpha` consistently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3f7121034832ab2afaa155eea5854)