### PR TITLE
Normalize fade alpha and accept percent values for condition fades

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -2710,6 +2710,10 @@ local function RefreshIcons(force)
                 end
                 if bucket and bucket.fade then
                     fadeAlpha = tonumber(bucket.fadeAlpha) or 0.5
+                    -- Backward compatibility: treat legacy/imported percent values like 50 as 0.5.
+                    if fadeAlpha > 1 then
+                        fadeAlpha = fadeAlpha / 100
+                    end
                 end
             end
 

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -4887,6 +4887,20 @@ end
 
 local _DA_SWIFTMEND_NEEDS = { "Rejuvenation", "Regrowth" }
 
+local function _NormalizeFadeAlpha(raw, fallback)
+  local v = tonumber(raw)
+  if not v then
+    v = fallback or 0.5
+  end
+  -- Backward compatibility: some profiles may store percentage values (e.g. 50).
+  if v > 1 then
+    v = v / 100
+  end
+  if v < 0.1 then v = 0.1 end
+  if v > 1 then v = 1 end
+  return v
+end
+
 local function _EvaluateVfxConditions(data)
   if not data or not data.conditions then
     return false, false, nil
@@ -4907,9 +4921,7 @@ local function _EvaluateVfxConditions(data)
           if entry.glow then glowOut = true end
           if entry.grey then greyOut = true end
           if entry.fade then
-            local fa = tonumber(entry.fadeAlpha) or 0.5
-            if fa < 0.1 then fa = 0.1 end
-            if fa > 1 then fa = 1 end
+            local fa = _NormalizeFadeAlpha(entry.fadeAlpha, 0.5)
             if fadeOut == nil or fa < fadeOut then
               fadeOut = fa
             end
@@ -4949,9 +4961,7 @@ local function CheckAbilityConditions(data)
     local grey = (c.greyscale and true) or false
     local fadeAlpha = nil
     if c.fade then
-      fadeAlpha = tonumber(c.fadeAlpha) or 0.5
-      if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
-      if fadeAlpha > 1 then fadeAlpha = 1 end
+      fadeAlpha = _NormalizeFadeAlpha(c.fadeAlpha, 0.5)
     end
     return true, glow, grey, fadeAlpha
   end
@@ -5319,13 +5329,9 @@ local function CheckAbilityConditions(data)
   local grey = (c.greyscale or vGrey) and true or false
   local fadeAlpha = nil
   if c.fade then
-    fadeAlpha = tonumber(c.fadeAlpha) or 0.5
+    fadeAlpha = _NormalizeFadeAlpha(c.fadeAlpha, 0.5)
   elseif vFade ~= nil then
-    fadeAlpha = tonumber(vFade)
-  end
-  if fadeAlpha ~= nil then
-    if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
-    if fadeAlpha > 1 then fadeAlpha = 1 end
+    fadeAlpha = _NormalizeFadeAlpha(vFade, 0.5)
   end
 
   if not show then
@@ -5351,9 +5357,7 @@ local function CheckItemConditions(data)
     local grey = (c.greyscale and true) or false
     local fadeAlpha = nil
     if c.fade then
-      fadeAlpha = tonumber(c.fadeAlpha) or 0.5
-      if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
-      if fadeAlpha > 1 then fadeAlpha = 1 end
+      fadeAlpha = _NormalizeFadeAlpha(c.fadeAlpha, 0.5)
     end
     return true, glow, grey, fadeAlpha
   end
@@ -5596,13 +5600,9 @@ local function CheckItemConditions(data)
   local grey = (c.greyscale or vGrey) and true or false
   local fadeAlpha = nil
   if c.fade then
-    fadeAlpha = tonumber(c.fadeAlpha) or 0.5
+    fadeAlpha = _NormalizeFadeAlpha(c.fadeAlpha, 0.5)
   elseif vFade ~= nil then
-    fadeAlpha = tonumber(vFade)
-  end
-  if fadeAlpha ~= nil then
-    if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
-    if fadeAlpha > 1 then fadeAlpha = 1 end
+    fadeAlpha = _NormalizeFadeAlpha(vFade, 0.5)
   end
 
   if not show then
@@ -5628,9 +5628,7 @@ local function CheckAuraConditions(data)
     local grey = (c.greyscale and true) or false
     local fadeAlpha = nil
     if c.fade then
-      fadeAlpha = tonumber(c.fadeAlpha) or 0.5
-      if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
-      if fadeAlpha > 1 then fadeAlpha = 1 end
+      fadeAlpha = _NormalizeFadeAlpha(c.fadeAlpha, 0.5)
     end
     return true, glow, grey, fadeAlpha
   end
@@ -6074,13 +6072,9 @@ local function CheckAuraConditions(data)
   local grey = (c.greyscale or vGrey) and true or false
   local fadeAlpha = nil
   if c.fade then
-    fadeAlpha = tonumber(c.fadeAlpha) or 0.5
+    fadeAlpha = _NormalizeFadeAlpha(c.fadeAlpha, 0.5)
   elseif vFade ~= nil then
-    fadeAlpha = tonumber(vFade)
-  end
-  if fadeAlpha ~= nil then
-    if fadeAlpha < 0.1 then fadeAlpha = 0.1 end
-    if fadeAlpha > 1 then fadeAlpha = 1 end
+    fadeAlpha = _NormalizeFadeAlpha(vFade, 0.5)
   end
 
   if not show then


### PR DESCRIPTION
### Motivation
- Fade alpha values were sometimes stored or entered as percentages (e.g. `50`) which were being interpreted as `50.0` and clamped to `1`, making alpha fade appear to not work.
- The goal is to make condition fade handling robust to both fractional (`0.5`) and percent (`50`) representations and to centralize normalization and clamping.

### Description
- Added a shared helper ` _NormalizeFadeAlpha(raw, fallback)` in `Modules/DoiteConditions.lua` that converts legacy percent-style values (>1) to fractions, applies the fallback, and clamps into the `[0.1, 1]` range.
- Replaced ad-hoc `tonumber(...)/clamp` logic in VFX, ability, item and aura condition evaluation paths to use ` _NormalizeFadeAlpha` so all fade computation is consistent.
- Updated the fallback path in `DoiteAuras.lua` (used by `RefreshIcons`) to convert stored percent values by dividing >1 values by `100` so refresh ticks correctly apply saved percent fades.
- Preserved the original minimum/maximum limits by ensuring `0.1` is the minimum effective fade and `1` is the maximum after normalization.

### Testing
- Attempted Lua syntax validation with `luac -p Modules/DoiteConditions.lua && luac -p DoiteAuras.lua`, but `luac` is not installed in the environment so syntax check could not be executed (failure due to missing tool).
- Ran repository searches to locate all `fadeAlpha` usages and confirm replacements were applied; the search completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6a66f7450832a906228c87937e107)