### PR TITLE
Add configurable fade (alpha) for visual-effect conditions and editor UI

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -2688,7 +2688,39 @@ local function RefreshIcons(force)
 
 
         f:SetScale((data and data.scale) or 1)
-        f:SetAlpha((data and data.alpha) or 1)
+        do
+            local a = (data and data.alpha) or 1
+
+            -- Primary source: runtime-evaluated fade from DoiteConditions.
+            local fadeAlpha = nil
+            if f._daUseFade and f._daFadeAlpha then
+                fadeAlpha = f._daFadeAlpha
+            end
+
+            -- Fallback: static per-icon fade from saved conditions,
+            -- so RefreshIcons won't wipe fade before/without an evaluation tick.
+            if (not fadeAlpha) and data and data.conditions then
+                local bucket = nil
+                if data.type == "Ability" then
+                    bucket = data.conditions.ability
+                elseif data.type == "Item" then
+                    bucket = data.conditions.item
+                elseif data.type == "Buff" or data.type == "Debuff" then
+                    bucket = data.conditions.aura
+                end
+                if bucket and bucket.fade then
+                    fadeAlpha = tonumber(bucket.fadeAlpha) or 0
+                end
+            end
+
+            if fadeAlpha then
+                if fadeAlpha < 0 then fadeAlpha = 0 end
+                if fadeAlpha > 1 then fadeAlpha = 1 end
+                a = a * fadeAlpha
+            end
+
+            f:SetAlpha(a)
+        end
         f:SetWidth(size); f:SetHeight(size)
 
         -- Do not re-anchor while a slide preview owns the frame for this tick AND do not re-anchor if this frame is currently being dragged (prevents snapping back)

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -4889,10 +4889,11 @@ local _DA_SWIFTMEND_NEEDS = { "Rejuvenation", "Regrowth" }
 
 local function _EvaluateVfxConditions(data)
   if not data or not data.conditions then
-    return false, false
+    return false, false, nil
   end
 
   local glowOut, greyOut = false, false
+  local fadeOut = nil
 
   local types = { "ability", "aura", "item" }
   local tIdx, typeKey
@@ -4905,12 +4906,20 @@ local function _EvaluateVfxConditions(data)
         if _AuraConditions_CheckEntry(entry) then
           if entry.glow then glowOut = true end
           if entry.grey then greyOut = true end
+          if entry.fade then
+            local fa = tonumber(entry.fadeAlpha) or 0
+            if fa < 0 then fa = 0 end
+            if fa > 1 then fa = 1 end
+            if fadeOut == nil or fa < fadeOut then
+              fadeOut = fa
+            end
+          end
         end
       end
     end
   end
 
-  return glowOut, greyOut
+  return glowOut, greyOut, fadeOut
 end
 
 -- ============================================================
@@ -4938,7 +4947,13 @@ local function CheckAbilityConditions(data)
   if _IsKeyUnderEdit(data.key) then
     local glow = (c.glow and true) or false
     local grey = (c.greyscale and true) or false
-    return true, glow, grey
+    local fadeAlpha = nil
+    if c.fade then
+      fadeAlpha = tonumber(c.fadeAlpha) or 0
+      if fadeAlpha < 0 then fadeAlpha = 0 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+    end
+    return true, glow, grey, fadeAlpha
   end
 
   -- "show" now represents ALL NON-MODE conditions.
@@ -5299,16 +5314,27 @@ local function CheckAbilityConditions(data)
       (data._daSoundGate and c.soundOffCDEnabled == true),
       c.soundOffCD)
 
-  local vGlow, vGrey = _EvaluateVfxConditions(data)
+  local vGlow, vGrey, vFade = _EvaluateVfxConditions(data)
   local glow = (c.glow or vGlow) and true or false
   local grey = (c.greyscale or vGrey) and true or false
+  local fadeAlpha = nil
+  if c.fade then
+    fadeAlpha = tonumber(c.fadeAlpha) or 0
+  elseif vFade ~= nil then
+    fadeAlpha = tonumber(vFade)
+  end
+  if fadeAlpha ~= nil then
+    if fadeAlpha < 0 then fadeAlpha = 0 end
+    if fadeAlpha > 1 then fadeAlpha = 1 end
+  end
 
   if not show then
     glow = false
     grey = false
+    fadeAlpha = nil
   end
 
-  return show, glow, grey
+  return show, glow, grey, fadeAlpha
 end
 
 -- ============================================================
@@ -5323,7 +5349,13 @@ local function CheckItemConditions(data)
   if _IsKeyUnderEdit(data.key) then
     local glow = (c.glow and true) or false
     local grey = (c.greyscale and true) or false
-    return true, glow, grey
+    local fadeAlpha = nil
+    if c.fade then
+      fadeAlpha = tonumber(c.fadeAlpha) or 0
+      if fadeAlpha < 0 then fadeAlpha = 0 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+    end
+    return true, glow, grey, fadeAlpha
   end
 
   local show = true
@@ -5344,7 +5376,7 @@ local function CheckItemConditions(data)
     data._daSoundGate = false
     local glow = c.glow and true or false
     local grey = c.greyscale and true or false
-    return false, glow, grey
+    return false, glow, grey, nil
   end
 
   if state.modeMatches == false then
@@ -5559,16 +5591,27 @@ local function CheckItemConditions(data)
       (data._daSoundGate and c.soundOffCDEnabled == true),
       c.soundOffCD)
 
-  local vGlow, vGrey = _EvaluateVfxConditions(data)
+  local vGlow, vGrey, vFade = _EvaluateVfxConditions(data)
   local glow = (c.glow or vGlow) and true or false
   local grey = (c.greyscale or vGrey) and true or false
+  local fadeAlpha = nil
+  if c.fade then
+    fadeAlpha = tonumber(c.fadeAlpha) or 0
+  elseif vFade ~= nil then
+    fadeAlpha = tonumber(vFade)
+  end
+  if fadeAlpha ~= nil then
+    if fadeAlpha < 0 then fadeAlpha = 0 end
+    if fadeAlpha > 1 then fadeAlpha = 1 end
+  end
 
   if not show then
     glow = false
     grey = false
+    fadeAlpha = nil
   end
 
-  return show, glow, grey
+  return show, glow, grey, fadeAlpha
 end
 
 -- ============================================================
@@ -5583,7 +5626,13 @@ local function CheckAuraConditions(data)
   if _IsKeyUnderEdit(data.key) then
     local glow = (c.glow and true) or false
     local grey = (c.greyscale and true) or false
-    return true, glow, grey
+    local fadeAlpha = nil
+    if c.fade then
+      fadeAlpha = tonumber(c.fadeAlpha) or 0
+      if fadeAlpha < 0 then fadeAlpha = 0 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+    end
+    return true, glow, grey, fadeAlpha
   end
 
   local name = data.displayName or data.name
@@ -6020,16 +6069,27 @@ local function CheckAuraConditions(data)
     end
   end
 
-  local vGlow, vGrey = _EvaluateVfxConditions(data)
+  local vGlow, vGrey, vFade = _EvaluateVfxConditions(data)
   local glow = (c.glow or vGlow) and true or false
   local grey = (c.greyscale or vGrey) and true or false
+  local fadeAlpha = nil
+  if c.fade then
+    fadeAlpha = tonumber(c.fadeAlpha) or 0
+  elseif vFade ~= nil then
+    fadeAlpha = tonumber(vFade)
+  end
+  if fadeAlpha ~= nil then
+    if fadeAlpha < 0 then fadeAlpha = 0 end
+    if fadeAlpha > 1 then fadeAlpha = 1 end
+  end
 
   if not show then
     glow = false
     grey = false
+    fadeAlpha = nil
   end
 
-  return show, glow, grey
+  return show, glow, grey, fadeAlpha
 end
 
 ---------------------------------------------------------------
@@ -6056,17 +6116,17 @@ function DoiteConditions:EvaluateAll()
         data.key = key
 
         if data.type == "Ability" or data.type == "Item" then
-          local show, glow, grey
+          local show, glow, grey, fadeAlpha
           if data.type == "Ability" then
-            show, glow, grey = CheckAbilityConditions(data)
+            show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
           else
-            show, glow, grey = CheckItemConditions(data)
+            show, glow, grey, fadeAlpha = CheckItemConditions(data)
           end
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
 
         elseif data.type == "Buff" or data.type == "Debuff" then
-          local show, glow, grey = CheckAuraConditions(data)
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
         end
       end
     end
@@ -6082,17 +6142,17 @@ function DoiteConditions:EvaluateAll()
           data.key = key
 
           if data.type == "Ability" or data.type == "Item" then
-            local show, glow, grey
+            local show, glow, grey, fadeAlpha
             if data.type == "Ability" then
-              show, glow, grey = CheckAbilityConditions(data)
+              show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
             else
-              show, glow, grey = CheckItemConditions(data)
+              show, glow, grey, fadeAlpha = CheckItemConditions(data)
             end
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
 
           elseif data.type == "Buff" or data.type == "Debuff" then
-            local show, glow, grey = CheckAuraConditions(data)
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
           end
         end
       end
@@ -6628,7 +6688,7 @@ end
 ---------------------------------------------------------------
 -- Apply visuals to icons
 ---------------------------------------------------------------
-function DoiteConditions:ApplyVisuals(key, show, glow, grey)
+function DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
   local frame = _GetIconFrame(key)
   if not frame then
     -- If icons rebuilt, forget any stale cached ref for this key and retry.
@@ -6799,6 +6859,8 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
     frame._daUseGlow = useGlow and true or false
     frame._daUseGlow = useGlow and true or false
     frame._daUseGreyscale = useGrey and true or false
+    frame._daUseFade = (fadeAlpha ~= nil) and true or false
+    frame._daFadeAlpha = fadeAlpha
     -- Sync with DoiteAuras.lua expectation
     frame._daGreyscale = frame._daUseGreyscale
   end
@@ -6856,13 +6918,21 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
           if slideActive then
             frame:ClearAllPoints()
             frame:SetPoint("CENTER", UIParent, "CENTER", baseX + dx, baseY + dy)
-            frame:SetAlpha(slideAlpha)
+            local baseAlpha = (dataTbl and dataTbl.alpha) or 1
+            if frame._daUseFade and frame._daFadeAlpha then
+              baseAlpha = baseAlpha * frame._daFadeAlpha
+            end
+            frame:SetAlpha(baseAlpha * (slideAlpha or 1))
           else
             -- When not sliding: do NOT force followers' points here.
             if not (isGrouped and not isLeader) then
               frame:ClearAllPoints()
               frame:SetPoint("CENTER", UIParent, "CENTER", baseX, baseY)
-              frame:SetAlpha((dataTbl and dataTbl.alpha) or 1)
+              local baseAlpha = (dataTbl and dataTbl.alpha) or 1
+              if frame._daUseFade and frame._daFadeAlpha then
+                baseAlpha = baseAlpha * frame._daFadeAlpha
+              end
+              frame:SetAlpha(baseAlpha)
             else
               -- Followers:
               -- Only re-anchor having a computed group position for this key.
@@ -6871,7 +6941,11 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
                 frame:SetPoint("CENTER", UIParent, "CENTER", baseX, baseY)
               end
               -- If !hasGroupPos: do not touch points this tick; avoid snapping back to original x/y.
-              frame:SetAlpha((dataTbl and dataTbl.alpha) or 1)
+              local baseAlpha = (dataTbl and dataTbl.alpha) or 1
+              if frame._daUseFade and frame._daFadeAlpha then
+                baseAlpha = baseAlpha * frame._daFadeAlpha
+              end
+              frame:SetAlpha(baseAlpha)
             end
           end
       end
@@ -6900,7 +6974,11 @@ function DoiteConditions:ApplyVisuals(key, show, glow, grey)
         frame:Show()
 
         if not slideActive then
-          frame:SetAlpha(1)
+          local baseAlpha = (dataTbl and dataTbl.alpha) or 1
+          if frame._daUseFade and frame._daFadeAlpha then
+            baseAlpha = baseAlpha * frame._daFadeAlpha
+          end
+          frame:SetAlpha(baseAlpha)
         end
       else
         frame:Hide()
@@ -7004,13 +7082,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
           data = key and live[key]
           if data and (data.type == "Ability" or data.type == "Item") then
             data.key = key
-            local show, glow, grey
+            local show, glow, grey, fadeAlpha
             if data.type == "Ability" then
-              show, glow, grey = CheckAbilityConditions(data)
+              show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
             else
-              show, glow, grey = CheckItemConditions(data)
+              show, glow, grey, fadeAlpha = CheckItemConditions(data)
             end
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
           end
           i = i + 1
         end
@@ -7028,13 +7106,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
             data = edit[key]
             if data and (data.type == "Ability" or data.type == "Item") then
               data.key = key
-              local show, glow, grey
+              local show, glow, grey, fadeAlpha
               if data.type == "Ability" then
-                show, glow, grey = CheckAbilityConditions(data)
+                show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
               else
-                show, glow, grey = CheckItemConditions(data)
+                show, glow, grey, fadeAlpha = CheckItemConditions(data)
               end
-              DoiteConditions:ApplyVisuals(key, show, glow, grey)
+              DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
             end
           end
           i = i + 1
@@ -7064,13 +7142,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
 
         if wantsLogic or wantsTime then
           data.key = key
-          local show, glow, grey
+          local show, glow, grey, fadeAlpha
           if data.type == "Ability" then
-            show, glow, grey = CheckAbilityConditions(data)
+            show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
           else
-            show, glow, grey = CheckItemConditions(data)
+            show, glow, grey, fadeAlpha = CheckItemConditions(data)
           end
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
         end
       end
     end
@@ -7094,13 +7172,13 @@ function DoiteConditions:EvaluateAbilities(doLogic, doTime)
 
           if wantsLogic or wantsTime then
             data.key = key
-            local show, glow, grey
+            local show, glow, grey, fadeAlpha
             if data.type == "Ability" then
-              show, glow, grey = CheckAbilityConditions(data)
+              show, glow, grey, fadeAlpha = CheckAbilityConditions(data)
             else
-              show, glow, grey = CheckItemConditions(data)
+              show, glow, grey, fadeAlpha = CheckItemConditions(data)
             end
-            DoiteConditions:ApplyVisuals(key, show, glow, grey)
+            DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
           end
         end
       end
@@ -7178,7 +7256,7 @@ local function _DoiteCustomEvaluateOne(key, data)
     data._daCustomHideBG = false
     data._daCustomRemaining = nil
     data._daCustomStacks = nil
-    DoiteConditions:ApplyVisuals(key, false, false, false)
+    DoiteConditions:ApplyVisuals(key, false, false, false, nil)
     return true
   end
 
@@ -7196,7 +7274,7 @@ local function _DoiteCustomEvaluateOne(key, data)
     data._daCustomHideBG = false
     data._daCustomRemaining = nil
     data._daCustomStacks = nil
-    DoiteConditions:ApplyVisuals(key, false, false, false)
+    DoiteConditions:ApplyVisuals(key, false, false, false, nil)
     return true
   end
 
@@ -7207,7 +7285,7 @@ local function _DoiteCustomEvaluateOne(key, data)
   data._daCustomRemaining = (type(remaining) == "number") and remaining or nil
   data._daCustomStacks = (type(stacks) == "number") and stacks or nil
 
-  DoiteConditions:ApplyVisuals(key, data._daCustomShow, false, false)
+  DoiteConditions:ApplyVisuals(key, data._daCustomShow, false, false, nil)
   return true
 end
 
@@ -7266,8 +7344,8 @@ function DoiteConditions:EvaluateAuras()
       elseif data.type == "Buff" or data.type == "Debuff" then
         data.key = key
 
-        local show, glow, grey = CheckAuraConditions(data)
-        DoiteConditions:ApplyVisuals(key, show, glow, grey)
+        local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+        DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
       end
     end
   end
@@ -7282,8 +7360,8 @@ function DoiteConditions:EvaluateAuras()
         elseif data.type == "Buff" or data.type == "Debuff" then
           data.key = key
 
-          local show, glow, grey = CheckAuraConditions(data)
-          DoiteConditions:ApplyVisuals(key, show, glow, grey)
+          local show, glow, grey, fadeAlpha = CheckAuraConditions(data)
+          DoiteConditions:ApplyVisuals(key, show, glow, grey, fadeAlpha)
         end
       end
     end

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -35,6 +35,24 @@ local VfxCond_RegisterManager
 local VfxCond_RefreshFromDB
 local VfxCond_ResetEditing
 
+local function _ParseFadeAlphaFromBox(box)
+  local pct = tonumber(box and box:GetText())
+  if not pct then
+    return 0
+  end
+  if pct < 0 then pct = 0 end
+  if pct > 100 then pct = 100 end
+  return pct / 100
+end
+
+local function _NormalizeFadeBox(box, alpha)
+  if not box then return end
+  local pct = math.floor(((alpha or 0) * 100) + 0.5)
+  if pct < 0 then pct = 0 end
+  if pct > 100 then pct = 100 end
+  box:SetText(tostring(pct))
+end
+
 local SOUND_FILES = {
   "JDO - Dont move, Shackles.ogg", "JDO - Loot banned.ogg", "Trend - Uwu.ogg",
   "MPOWA - Aggro.ogg", "MPOWA - Arrow Swoosh.ogg", "MPOWA - Bam.ogg", "MPOWA - Bigkiss.ogg", "MPOWA - Bite.ogg", "MPOWA - Burp.ogg", "MPOWA - Cat.ogg", "MPOWA - Chant (1).ogg", "MPOWA - Chant (2).ogg", "MPOWA - Chimes.ogg", "MPOWA - Cookie.ogg", "MPOWA - ESpark.ogg", "MPOWA - Fireball.ogg", "MPOWA - Gasp.ogg",
@@ -1579,6 +1597,24 @@ local function CreateConditionsUI()
     return eb
   end
 
+  local function MakeMiniFadeSlider(name, x, y)
+    local parent = _Parent()
+    local eb = CreateFrame("EditBox", name, parent, "InputBoxTemplate")
+    eb:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+    eb:SetWidth(26)
+    eb:SetHeight(16)
+    eb:SetAutoFocus(false)
+    eb:SetJustifyH("CENTER")
+    eb:SetFontObject("GameFontNormalSmall")
+    eb:SetNumeric(true)
+
+    local pct = eb:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    pct:SetPoint("LEFT", eb, "RIGHT", 4, 0)
+    pct:SetText("|cffffd000%|r")
+    eb._pct = pct
+    return eb
+  end
+
   -- renders a small bold white title with a "split" separator line that does not pass under the text
   local function MakeSeparatorRow(parent, y, title, drawLine)
     drawLine = (drawLine ~= false)
@@ -1801,6 +1837,8 @@ local function CreateConditionsUI()
 
   condFrame.cond_ability_glow = MakeCheck("DoiteCond_Ability_Glow", "Glow", 0, row5_y)
   condFrame.cond_ability_greyscale = MakeCheck("DoiteCond_Ability_Greyscale", "Grey", 70, row5_y)
+  condFrame.cond_ability_fade = MakeCheck("DoiteCond_Ability_Fade", "Fade", 140, row5_y)
+  condFrame.cond_ability_fade_slider = MakeMiniFadeSlider("DoiteCond_Ability_FadeSlider", 200, row5_y - 2)
   condFrame.cond_ability_slider_glow = MakeCheck("DoiteCond_Ability_SliderGlow", "CD Glow", 140, row5_y)
   condFrame.cond_ability_slider_grey = MakeCheck("DoiteCond_Ability_SliderGrey", "CD Grey", 220, row5_y)
   SetSeparator("ability", 5, "VISUAL EFFECTS", true, true)
@@ -2023,6 +2061,8 @@ local function CreateConditionsUI()
 
   condFrame.cond_aura_glow = MakeCheck("DoiteCond_Aura_Glow", "Glow", 0, row5_y)
   condFrame.cond_aura_greyscale = MakeCheck("DoiteCond_Aura_Greyscale", "Grey", 70, row5_y)
+  condFrame.cond_aura_fade = MakeCheck("DoiteCond_Aura_Fade", "Fade", 140, row5_y)
+  condFrame.cond_aura_fade_slider = MakeMiniFadeSlider("DoiteCond_Aura_FadeSlider", 200, row5_y - 2)
   SetSeparator("aura", 5, "VISUAL EFFECTS", true, true)
 
   -- AURA ROW: TARGET DISTANCE & TYPE
@@ -2291,6 +2331,8 @@ local function CreateConditionsUI()
   -- VISUAL EFFECTS
   condFrame.cond_item_glow = MakeCheck("DoiteCond_Item_Glow", "Glow", 0, row7_y)
   condFrame.cond_item_greyscale = MakeCheck("DoiteCond_Item_Greyscale", "Grey", 70, row7_y)
+  condFrame.cond_item_fade = MakeCheck("DoiteCond_Item_Fade", "Fade", 140, row7_y)
+  condFrame.cond_item_fade_slider = MakeMiniFadeSlider("DoiteCond_Item_FadeSlider", 200, row7_y - 2)
   SetSeparator("item", 7, "VISUAL EFFECTS", true, true)
 
   -- ITEM ROW: TARGET DISTANCE & TYPE
@@ -3647,6 +3689,7 @@ function UpdateItemStacksForMissing()
     SafeEvaluate()
   end)
 
+
   -- Aura glow / greyscale
   condFrame.cond_aura_glow:SetScript("OnClick", function()
     if not currentKey then
@@ -3675,6 +3718,37 @@ function UpdateItemStacksForMissing()
     SafeRefresh()
     SafeEvaluate()
   end)
+
+  condFrame.cond_aura_fade:SetScript("OnClick", function()
+    if not currentKey then
+      this:SetChecked(false)
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.aura = d.conditions.aura or {}
+    d.conditions.aura.fade = this:GetChecked() and true or false
+    if d.conditions.aura.fade and not d.conditions.aura.fadeAlpha then
+      d.conditions.aura.fadeAlpha = 0
+    end
+    UpdateCondFrameForKey(currentKey)
+    SafeRefresh()
+    SafeEvaluate()
+  end)
+
+  local function SaveAuraFadeAlpha()
+    if not currentKey then return end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.aura = d.conditions.aura or {}
+    d.conditions.aura.fadeAlpha = _ParseFadeAlphaFromBox(condFrame.cond_aura_fade_slider)
+    _NormalizeFadeBox(condFrame.cond_aura_fade_slider, d.conditions.aura.fadeAlpha)
+    SafeRefresh()
+    SafeEvaluate()
+  end
+  condFrame.cond_aura_fade_slider:SetScript("OnEnterPressed", function() SaveAuraFadeAlpha(); this:ClearFocus() end)
+  condFrame.cond_aura_fade_slider:SetScript("OnEditFocusLost", SaveAuraFadeAlpha)
+  condFrame.cond_aura_fade_slider:SetScript("OnEscapePressed", function() this:ClearFocus() end)
 
   -- === Combo points enable toggles ===
   condFrame.cond_ability_cp_cb:SetScript("OnClick", function()
@@ -4000,6 +4074,35 @@ function UpdateItemStacksForMissing()
     SafeRefresh();
     SafeEvaluate()
   end)
+  condFrame.cond_item_fade:SetScript("OnClick", function()
+    if not currentKey then
+      this:SetChecked(false)
+      return
+    end
+    local d = EnsureDBEntry(currentKey);
+    d.conditions.item = d.conditions.item or {}
+    d.conditions.item.fade = this:GetChecked() and true or false
+    if d.conditions.item.fade and not d.conditions.item.fadeAlpha then
+      d.conditions.item.fadeAlpha = 0
+    end
+    UpdateCondFrameForKey(currentKey);
+    SafeRefresh();
+    SafeEvaluate()
+  end)
+
+  local function SaveItemFadeAlpha()
+    if not currentKey then return end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions.item = d.conditions.item or {}
+    d.conditions.item.fadeAlpha = _ParseFadeAlphaFromBox(condFrame.cond_item_fade_slider)
+    _NormalizeFadeBox(condFrame.cond_item_fade_slider, d.conditions.item.fadeAlpha)
+    SafeRefresh()
+    SafeEvaluate()
+  end
+  condFrame.cond_item_fade_slider:SetScript("OnEnterPressed", function() SaveItemFadeAlpha(); this:ClearFocus() end)
+  condFrame.cond_item_fade_slider:SetScript("OnEditFocusLost", SaveItemFadeAlpha)
+  condFrame.cond_item_fade_slider:SetScript("OnEscapePressed", function() this:ClearFocus() end)
+
 
   -- Item text: remaining time
   condFrame.cond_item_text_time:SetScript("OnClick", function()
@@ -4991,6 +5094,36 @@ function UpdateItemStacksForMissing()
     SafeRefresh()
     SafeEvaluate()
   end)
+  condFrame.cond_ability_fade:SetScript("OnClick", function()
+    if not currentKey then
+      this:SetChecked(false)
+      return
+    end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.ability = d.conditions.ability or {}
+    d.conditions.ability.fade = this:GetChecked() and true or false
+    if d.conditions.ability.fade and not d.conditions.ability.fadeAlpha then
+      d.conditions.ability.fadeAlpha = 0
+    end
+    UpdateCondFrameForKey(currentKey)
+    SafeRefresh()
+    SafeEvaluate()
+  end)
+
+  local function SaveAbilityFadeAlpha()
+    if not currentKey then return end
+    local d = EnsureDBEntry(currentKey)
+    d.conditions = d.conditions or {}
+    d.conditions.ability = d.conditions.ability or {}
+    d.conditions.ability.fadeAlpha = _ParseFadeAlphaFromBox(condFrame.cond_ability_fade_slider)
+    _NormalizeFadeBox(condFrame.cond_ability_fade_slider, d.conditions.ability.fadeAlpha)
+    SafeRefresh()
+    SafeEvaluate()
+  end
+  condFrame.cond_ability_fade_slider:SetScript("OnEnterPressed", function() SaveAbilityFadeAlpha(); this:ClearFocus() end)
+  condFrame.cond_ability_fade_slider:SetScript("OnEditFocusLost", SaveAbilityFadeAlpha)
+  condFrame.cond_ability_fade_slider:SetScript("OnEscapePressed", function() this:ClearFocus() end)
 
   -- Form dropdowns are initialized/updated from UpdateConditionsUI
   condFrame.cond_ability_formDD:Hide()
@@ -5021,6 +5154,8 @@ function UpdateItemStacksForMissing()
   condFrame.cond_ability_remaining_val:Hide()
   condFrame.cond_ability_remaining_val_enter:Hide()
   condFrame.cond_ability_greyscale:Hide()
+  condFrame.cond_ability_fade:Hide()
+  condFrame.cond_ability_fade_slider:Hide()
   condFrame.cond_ability_cp_cb:Hide()
   condFrame.cond_ability_cp_comp:Hide()
   condFrame.cond_ability_cp_val:Hide()
@@ -5083,6 +5218,8 @@ function UpdateItemStacksForMissing()
   condFrame.cond_aura_stacks_val:Hide()
   condFrame.cond_aura_stacks_val_enter:Hide()
   condFrame.cond_aura_greyscale:Hide()
+  condFrame.cond_aura_fade:Hide()
+  condFrame.cond_aura_fade_slider:Hide()
   condFrame.cond_aura_mine:Hide()
   if condFrame.cond_aura_others then
     condFrame.cond_aura_others:Hide()
@@ -5118,6 +5255,8 @@ function UpdateItemStacksForMissing()
   condFrame.cond_item_target_self:Hide()
   condFrame.cond_item_glow:Hide()
   condFrame.cond_item_greyscale:Hide()
+  condFrame.cond_item_fade:Hide()
+  condFrame.cond_item_fade_slider:Hide()
   condFrame.cond_item_text_time:Hide()
   condFrame.cond_item_power:Hide()
   condFrame.cond_item_power_comp:Hide()
@@ -6918,6 +7057,9 @@ do
     if row.abilityDD then row.abilityDD:Hide() end
     if row.glowCB then row.glowCB:Hide() end
     if row.greyCB then row.greyCB:Hide() end
+    if row.fadeCB then row.fadeCB:Hide() end
+    if row.fadeSlider then row.fadeSlider:Hide() end
+    if row.fadeSliderPct then row.fadeSliderPct:Hide() end
   
     if row.stacksLabel then row.stacksLabel:Hide() end
     if row.stacksCB then row.stacksCB:Hide() end
@@ -7090,9 +7232,28 @@ do
         row.greyCB:ClearAllPoints()
         row.glowCB:SetPoint("TOPLEFT", row, "TOPLEFT", 0, -14)
         row.greyCB:SetPoint("LEFT", row.glowCB, "RIGHT", 40, 0)
+        if row.fadeCB then
+          row.fadeCB:ClearAllPoints()
+          row.fadeCB:SetPoint("LEFT", row.greyCB, "RIGHT", 40, 0)
+        end
+        if row.fadeSlider then
+          row.fadeSlider:ClearAllPoints()
+          row.fadeSlider:SetPoint("LEFT", row.fadeCB, "RIGHT", 45, 0)
+          if row.fadeSliderPct then
+            row.fadeSliderPct:ClearAllPoints()
+            row.fadeSliderPct:SetPoint("LEFT", row.fadeSlider, "RIGHT", 12, 0)
+          end
+        end
   
         row.glowCB:Show()
         row.greyCB:Show()
+        if row.fadeCB then
+          row.fadeCB:Show()
+          if row.fadeCB:GetChecked() and row.fadeSlider then
+            row.fadeSlider:Show()
+            if row.fadeSliderPct then row.fadeSliderPct:Show() end
+          end
+        end
       end
     end
   end
@@ -7201,6 +7362,38 @@ do
         end)
       end
 
+      if row.fadeCB then
+        row.fadeCB:SetChecked(entry and entry.fade)
+        row.fadeCB:SetScript("OnClick", function()
+          local list = VfxCond_GetListForType(typeKey)
+          if list and list[row._entryIndex] then
+            list[row._entryIndex].fade = this:GetChecked() and true or nil
+            if list[row._entryIndex].fade and not list[row._entryIndex].fadeAlpha then
+              list[row._entryIndex].fadeAlpha = 0
+            end
+            SafeRefresh(); SafeEvaluate()
+            UpdateCondFrameForKey(currentKey)
+          end
+        end)
+      end
+      if row.fadeSlider then
+        local fadeAlpha = tonumber(entry and entry.fadeAlpha) or 0
+        if fadeAlpha < 0 then fadeAlpha = 0 end
+        if fadeAlpha > 1 then fadeAlpha = 1 end
+        row.fadeSlider:SetText(tostring(math.floor((fadeAlpha * 100) + 0.5)))
+        local function SaveRowFadeAlpha()
+          local list = VfxCond_GetListForType(typeKey)
+          if list and list[row._entryIndex] then
+            list[row._entryIndex].fadeAlpha = _ParseFadeAlphaFromBox(row.fadeSlider)
+            _NormalizeFadeBox(row.fadeSlider, list[row._entryIndex].fadeAlpha)
+            SafeRefresh(); SafeEvaluate()
+          end
+        end
+        row.fadeSlider:SetScript("OnEnterPressed", function() SaveRowFadeAlpha(); this:ClearFocus() end)
+        row.fadeSlider:SetScript("OnEditFocusLost", SaveRowFadeAlpha)
+        row.fadeSlider:SetScript("OnEscapePressed", function() this:ClearFocus() end)
+      end
+
       VfxCond_SetRowState(row, "SAVED")
       row:Show()
     end
@@ -7283,6 +7476,8 @@ do
 	  mode = mode,
 	  unit = unit,
 	  name = VfxCond_TitleCase(text),
+	  fade = nil,
+	  fadeAlpha = 0,
 	}
 
 	-- only for aura (buff/debuff), store optional stack settings
@@ -7460,6 +7655,16 @@ do
 
     row.glowCB = CreateMiniCheck("Glow")
     row.greyCB = CreateMiniCheck("Grey")
+    row.fadeCB = CreateMiniCheck("Fade")
+    row.fadeSlider = CreateFrame("EditBox", nil, row, "InputBoxTemplate")
+    row.fadeSlider:SetWidth(24)
+    row.fadeSlider:SetHeight(16)
+    row.fadeSlider:SetAutoFocus(false)
+    row.fadeSlider:SetJustifyH("CENTER")
+    row.fadeSlider:SetFontObject("GameFontNormalSmall")
+    row.fadeSlider:SetNumeric(true)
+    row.fadeSliderPct = row:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    row.fadeSliderPct:SetText("|cffffd000%|r")
 
     row.closeBtn:SetText("X")
 
@@ -7658,7 +7863,7 @@ do
       label:SetPoint("TOPLEFT", anchorFrame, "TOPLEFT", 0, -15)
       label:SetJustifyH("LEFT")
       label:SetTextColor(1, 0.82, 0)
-      label:SetText("Add visual effect conditions for glow/grey:")
+      label:SetText("Add visual effect conditions for glow/grey/fade:")
       mgr.label = label
     end
 
@@ -7727,6 +7932,14 @@ local function UpdateConditionsUI(data)
   end
   _HideSoundControls()
 
+  -- Reset fade controls upfront to prevent visual leakage between icon categories.
+  if condFrame.cond_ability_fade then condFrame.cond_ability_fade:Hide() end
+  if condFrame.cond_ability_fade_slider then condFrame.cond_ability_fade_slider:Hide() end
+  if condFrame.cond_aura_fade then condFrame.cond_aura_fade:Hide() end
+  if condFrame.cond_aura_fade_slider then condFrame.cond_aura_fade_slider:Hide() end
+  if condFrame.cond_item_fade then condFrame.cond_item_fade:Hide() end
+  if condFrame.cond_item_fade_slider then condFrame.cond_item_fade_slider:Hide() end
+
   -- Custom controls are hidden by default; shown only for Custom type.
   if condFrame.cond_custom_function_edit then
     condFrame.cond_custom_function_edit:Hide()
@@ -7779,6 +7992,7 @@ local function UpdateConditionsUI(data)
     condFrame.cond_ability_power:Show()
     condFrame.cond_ability_glow:Show()
     condFrame.cond_ability_greyscale:Show()
+    condFrame.cond_ability_fade:Show()
     condFrame.cond_ability_slider:Show()
     condFrame.cond_ability_remaining_cb:Show()
 
@@ -7950,6 +8164,16 @@ local function UpdateConditionsUI(data)
     -- glow & greyscale states
     condFrame.cond_ability_glow:SetChecked((c.ability and c.ability.glow) or false)
     condFrame.cond_ability_greyscale:SetChecked((c.ability and c.ability.greyscale) or false)
+    condFrame.cond_ability_fade:SetChecked((c.ability and c.ability.fade) or false)
+    if (c.ability and c.ability.fade) then
+      local fadeAlpha = tonumber(c.ability.fadeAlpha) or 0
+      if fadeAlpha < 0 then fadeAlpha = 0 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+      condFrame.cond_ability_fade_slider:SetText(tostring(math.floor((fadeAlpha * 100) + 0.5)))
+      condFrame.cond_ability_fade_slider:Show()
+    else
+      condFrame.cond_ability_fade_slider:Hide()
+    end
 
     -- slider vs remaining
     local slidEnabled = (c.ability and c.ability.slider) and true or false
@@ -8153,6 +8377,8 @@ local function UpdateConditionsUI(data)
     condFrame.cond_aura_onself:Hide()
     condFrame.cond_aura_glow:Hide()
     condFrame.cond_aura_greyscale:Hide()
+    condFrame.cond_aura_fade:Hide()
+    condFrame.cond_aura_fade_slider:Hide()
     condFrame.cond_aura_remaining_cb:Hide()
     condFrame.cond_aura_remaining_comp:Hide()
     condFrame.cond_aura_remaining_val:Hide()
@@ -8289,6 +8515,12 @@ local function UpdateConditionsUI(data)
     end
     if condFrame.cond_item_greyscale then
       condFrame.cond_item_greyscale:Hide()
+    end
+    if condFrame.cond_item_fade then
+      condFrame.cond_item_fade:Hide()
+    end
+    if condFrame.cond_item_fade_slider then
+      condFrame.cond_item_fade_slider:Hide()
     end
     if condFrame.cond_item_text_time then
       condFrame.cond_item_text_time:Hide()
@@ -8871,9 +9103,20 @@ local ic = c.item or {}
     -- VISUAL EFFECTS
     condFrame.cond_item_glow:Show()
     condFrame.cond_item_greyscale:Show()
+    condFrame.cond_item_fade:Show()
     condFrame.cond_item_text_time:Show()
     condFrame.cond_item_glow:SetChecked(ic.glow == true)
     condFrame.cond_item_greyscale:SetChecked(ic.greyscale == true)
+    condFrame.cond_item_fade:SetChecked(ic.fade == true)
+    if ic.fade == true then
+      local fadeAlpha = tonumber(ic.fadeAlpha) or 0
+      if fadeAlpha < 0 then fadeAlpha = 0 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+      condFrame.cond_item_fade_slider:SetText(tostring(math.floor((fadeAlpha * 100) + 0.5)))
+      condFrame.cond_item_fade_slider:Show()
+    else
+      condFrame.cond_item_fade_slider:Hide()
+    end
 
     -- Keep item text-time label constant
     do
@@ -9206,6 +9449,8 @@ local ic = c.item or {}
     condFrame.cond_ability_power_val_enter:Hide()
     condFrame.cond_ability_glow:Hide()
     condFrame.cond_ability_greyscale:Hide()
+    condFrame.cond_ability_fade:Hide()
+    condFrame.cond_ability_fade_slider:Hide()
     condFrame.cond_ability_slider:Hide()
     condFrame.cond_ability_slider_dir:Hide()
     condFrame.cond_ability_remaining_cb:Hide()
@@ -9259,6 +9504,8 @@ local ic = c.item or {}
     end
     condFrame.cond_aura_glow:Hide()
     condFrame.cond_aura_greyscale:Hide()
+    condFrame.cond_aura_fade:Hide()
+    condFrame.cond_aura_fade_slider:Hide()
     condFrame.cond_aura_power:Hide()
     condFrame.cond_aura_power_comp:Hide()
     condFrame.cond_aura_power_val:Hide()
@@ -9372,6 +9619,8 @@ local ic = c.item or {}
     _Hide(condFrame.cond_ability_target_dead)
     _Hide(condFrame.cond_ability_glow)
     _Hide(condFrame.cond_ability_greyscale)
+    _Hide(condFrame.cond_ability_fade)
+    _Hide(condFrame.cond_ability_fade_slider)
     _Hide(condFrame.cond_ability_slider)
     _Hide(condFrame.cond_ability_slider_dir)
     _Hide(condFrame.cond_ability_slider_glow)
@@ -9413,6 +9662,8 @@ local ic = c.item or {}
     _Hide(condFrame.cond_aura_target_dead)
     _Hide(condFrame.cond_aura_glow)
     _Hide(condFrame.cond_aura_greyscale)
+    _Hide(condFrame.cond_aura_fade)
+    _Hide(condFrame.cond_aura_fade_slider)
     _Hide(condFrame.cond_aura_distanceDD)
     _Hide(condFrame.cond_aura_unitTypeDD)
     _Hide(condFrame.cond_aura_power)
@@ -9470,6 +9721,8 @@ local ic = c.item or {}
     _Hide(condFrame.cond_item_target_dead)
     _Hide(condFrame.cond_item_glow)
     _Hide(condFrame.cond_item_greyscale)
+    _Hide(condFrame.cond_item_fade)
+    _Hide(condFrame.cond_item_fade_slider)
     _Hide(condFrame.cond_item_text_time)
     _Hide(condFrame.cond_item_text_time_override)
     _Hide(condFrame.cond_item_text_override_note)
@@ -9554,6 +9807,7 @@ local ic = c.item or {}
     condFrame.cond_aura_sound_onfade_dd:Show()
     condFrame.cond_aura_glow:Show()
     condFrame.cond_aura_greyscale:Show()
+    condFrame.cond_aura_fade:Show()
 
     -- mode
     local amode = (c.aura and c.aura.mode) or nil
@@ -9699,6 +9953,16 @@ local ic = c.item or {}
 
     condFrame.cond_aura_glow:SetChecked((c.aura and c.aura.glow) or false)
     condFrame.cond_aura_greyscale:SetChecked((c.aura and c.aura.greyscale) or false)
+    condFrame.cond_aura_fade:SetChecked((c.aura and c.aura.fade) or false)
+    if (c.aura and c.aura.fade) then
+      local fadeAlpha = tonumber(c.aura.fadeAlpha) or 0
+      if fadeAlpha < 0 then fadeAlpha = 0 end
+      if fadeAlpha > 1 then fadeAlpha = 1 end
+      condFrame.cond_aura_fade_slider:SetText(tostring(math.floor((fadeAlpha * 100) + 0.5)))
+      condFrame.cond_aura_fade_slider:Show()
+    else
+      condFrame.cond_aura_fade_slider:Hide()
+    end
 
     local auraSoundGainOn = (c.aura and c.aura.soundOnGainEnabled) == true
     local auraSoundFadeOn = (c.aura and c.aura.soundOnFadeEnabled) == true
@@ -10175,6 +10439,8 @@ local ic = c.item or {}
     condFrame.cond_ability_power_val_enter:Hide()
     condFrame.cond_ability_glow:Hide()
     condFrame.cond_ability_greyscale:Hide()
+    condFrame.cond_ability_fade:Hide()
+    condFrame.cond_ability_fade_slider:Hide()
     condFrame.cond_ability_slider:Hide()
     condFrame.cond_ability_slider_dir:Hide()
     condFrame.cond_ability_remaining_cb:Hide()
@@ -10271,6 +10537,12 @@ local ic = c.item or {}
     end
     if condFrame.cond_item_greyscale then
       condFrame.cond_item_greyscale:Hide()
+    end
+    if condFrame.cond_item_fade then
+      condFrame.cond_item_fade:Hide()
+    end
+    if condFrame.cond_item_fade_slider then
+      condFrame.cond_item_fade_slider:Hide()
     end
     if condFrame.cond_item_text_time then
       condFrame.cond_item_text_time:Hide()


### PR DESCRIPTION
### Motivation

- Provide per-condition and per-vfx fade control so icons can be partially faded via conditions (glow/grey + fade). 
- Preserve and apply fade alpha reliably during runtime updates and slide previews to avoid flicker or alpha being wiped by refresh logic.
- Expose fade controls in the conditions editor and in individual vfx entries so users can set a percentage instead of a binary effect.

### Description

- DoiteConditions: _EvaluateVfxConditions now computes a minimum fade alpha from vfx entries and CheckAbility/CheckItem/CheckAura return a `fadeAlpha` value; evaluation passes `fadeAlpha` through `EvaluateAll`, `EvaluateAbilities`, `EvaluateAuras` into `ApplyVisuals`.
- DoiteConditions: `ApplyVisuals` stores fade flags on the frame (`_daUseFade`, `_daFadeAlpha`) and threads fade into anchors/slide logic and visibility change handling so alpha is multiplied by saved/base alpha and slide alpha where appropriate.
- DoiteAuras: `RefreshIcons` reads runtime fade (`f._daFadeAlpha`) or falls back to saved `data.conditions.*.fadeAlpha` and applies the computed alpha when setting the frame alpha to avoid wiping fades between evaluation ticks.
- DoiteEdit: editor UI extended with per-type fade checkboxes and small percentage editboxes (`MakeMiniFadeSlider`), parsing/normalization utilities, handlers to save `fade` and `fadeAlpha` into DB, and vfx-row UI extended to support `fade` + `fadeAlpha` on each saved/saved-entry row; label text updated to mention fade.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3f7121034832ab2afaa155eea5854)