### PR TITLE
Ignore GCD-length cooldowns in ability remaining text

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -6307,9 +6307,9 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
     end
     dur = dur or 0
 
-    -- 1) ON COOLDOWN: always show for the entire real cooldown.
+    -- 1) ON COOLDOWN: only show real cooldowns (ignore pure GCD blips).
     if ca.mode == "oncd" or ca.mode == "usableoncd" or ca.mode == "nocdoncd" then
-      return (dur > 0)
+      return (dur > 1.6)
     end
 
     -- 2) USABLE / NOTCD with slider: slide can override the 1.6s/GCD filter


### PR DESCRIPTION
### Motivation
- Prevent spurious remaining-time text when a tracked ability briefly shows a GCD-length cooldown (∼1.5s) due to global cooldown interactions between abilities in mixed modes.

### Description
- Modify `_ShowAbilityTime` in `Modules/DoiteConditions.lua` so `oncd`/`usableoncd`/`nocdoncd` only return true for real cooldowns by requiring `dur > 1.6` (change around `L6304-L6313`).

### Testing
- Attempted a syntax check with `luac -p Modules/DoiteConditions.lua`, but `luac` is not installed in this environment so the check could not be performed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7e6f49b2c832aa8a6b65abb224e25)