### PR TITLE
Add pet spellbook handling and pet-tracking UI for abilities/auras

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -774,39 +774,45 @@ local function DA_RebuildAbilityDropDown()
 
     local seen = {}
 
-    -- linear scan over spellbook, filter passives by IsPassiveSpell + rank "Passive"
-    local i = 1
-    while true do
-        local name, rank = GetSpellName(i, BOOKTYPE_SPELL)
-        if not name then
-            break
-        end
+    local function scanBook(bookType)
+        local i = 1
+        while true do
+            local name, rank = GetSpellName(i, bookType)
+            if not name then
+                break
+            end
 
-        local isPassive = false
+            local isPassive = false
 
-        if IsPassiveSpell then
-            -- best-effort: use IsPassiveSpell if available (signature may differ)
-            local ok, passive = pcall(IsPassiveSpell, i, BOOKTYPE_SPELL)
-            if ok and passive then
+            if IsPassiveSpell then
+                -- best-effort: use IsPassiveSpell if available (signature may differ)
+                local ok, passive = pcall(IsPassiveSpell, i, bookType)
+                if ok and passive then
+                    isPassive = true
+                end
+            end
+
+            -- Fallback: many passives have "Passive" in the rank string
+            if (not isPassive) and rank and string.find(rank, "Passive") then
                 isPassive = true
             end
-        end
 
-        -- Fallback: many passives have "Passive" in the rank string
-        if (not isPassive) and rank and string.find(rank, "Passive") then
-            isPassive = true
-        end
-
-        if (not isPassive) and name ~= "" then
-            local lname = string.lower(name or "")
-            if not seen[lname] then
-                seen[lname] = true
-                DA_AddAbilityOption(name)
+            if (not isPassive) and name ~= "" then
+                local lname = string.lower(name or "")
+                if not seen[lname] then
+                    seen[lname] = true
+                    DA_AddAbilityOption(name)
+                end
             end
-        end
 
-        i = i + 1
+            i = i + 1
+        end
     end
+
+    -- Player abilities
+    scanBook(BOOKTYPE_SPELL)
+    -- Pet abilities (Hunters/Warlocks etc.)
+    scanBook(BOOKTYPE_PET)
 
     -- Sort 0–9 A–Z (case-insensitive; ties broken by original)
     table.sort(DA_AbilityOptions, function(a, b)
@@ -2017,7 +2023,10 @@ local function FindSpellBookSlot(spellName)
     if type(GetSpellSlotTypeIdForName) == "function" then
         local ok, slot, bookType = pcall(GetSpellSlotTypeIdForName, spellName)
         if ok and slot and slot > 0 and (bookType == "spell" or bookType == "pet" or bookType == "unknown") then
-            return slot
+            if bookType == "pet" then
+                return slot, BOOKTYPE_PET
+            end
+            return slot, BOOKTYPE_SPELL
         end
     end
 
@@ -2033,11 +2042,23 @@ local function FindSpellBookSlot(spellName)
                 local idx  = offset + i
                 local name = GetSpellName(idx, BOOKTYPE_SPELL)
                 if name == spellName then
-                    return idx
+                    return idx, BOOKTYPE_SPELL
                 end
             end
         end
     end
+
+    -- Fallback pet spellbook scan
+    local p = 1
+    while true do
+        local name = GetSpellName(p, BOOKTYPE_PET)
+        if not name then break end
+        if name == spellName then
+            return p, BOOKTYPE_PET
+        end
+        p = p + 1
+    end
+
     return nil
 end
 
@@ -2455,15 +2476,16 @@ local function RefreshIcons(force)
         -- For Abilities only: single cheap fallback via spell slot (Nampower-accelerated)
         if not tex and typ == "Ability" then
             local slot = slotCache[displayName]
+            local slotBookType = BOOKTYPE_SPELL
             if slot == nil then
-                slot = FindSpellBookSlot(displayName)
+                slot, slotBookType = FindSpellBookSlot(displayName)
                 slotCache[displayName] = slot or false
             elseif slot == false then
                 slot = nil
             end
 
             if slot and GetSpellTexture then
-                tex = GetSpellTexture(slot, BOOKTYPE_SPELL)
+                tex = GetSpellTexture(slot, slotBookType or BOOKTYPE_SPELL)
             end
         end
 
@@ -3604,9 +3626,9 @@ addBtn:SetScript("OnClick", function()
   end
 
   if t == "Ability" then
-    local slot = FindSpellBookSlot(name)
+    local slot, slotBookType = FindSpellBookSlot(name)
     if slot and GetSpellTexture then
-      local tex = GetSpellTexture(slot, BOOKTYPE_SPELL)
+      local tex = GetSpellTexture(slot, slotBookType or BOOKTYPE_SPELL)
       if tex then
         cache[name]       = tex
         entry.iconTexture = tex

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -150,6 +150,7 @@ end
 -- Spell index cache (must be defined before any usage)
 local SpellIndexCache = {}
 _G.DoiteConditions_SpellIndexCache = SpellIndexCache
+_G.DoiteConditions_SpellBookTypeCache = _G.DoiteConditions_SpellBookTypeCache or {}
 
 local _isWarrior = false
 
@@ -166,8 +167,9 @@ local function _GetSpellIndexByName(spellName)
   -- Nampower fast path - GetSpellSlotTypeIdForName(spellName)
   if GetSpellSlotTypeIdForName then
     local slot, bookType = GetSpellSlotTypeIdForName(spellName)
-    if slot and slot > 0 and bookType == "spell" then
+    if slot and slot > 0 and (bookType == "spell" or bookType == "pet") then
       SpellIndexCache[spellName] = slot
+      _G.DoiteConditions_SpellBookTypeCache[spellName] = (bookType == "pet") and BOOKTYPE_PET or BOOKTYPE_SPELL
       return slot
     end
   end
@@ -181,12 +183,29 @@ local function _GetSpellIndexByName(spellName)
     end
     if s == spellName then
       SpellIndexCache[spellName] = i
+      _G.DoiteConditions_SpellBookTypeCache[spellName] = BOOKTYPE_SPELL
+      return i
+    end
+    i = i + 1
+  end
+
+  -- pet spellbook fallback
+  i = 1
+  while i <= 200 do
+    local s = GetSpellName(i, BOOKTYPE_PET)
+    if not s then
+      break
+    end
+    if s == spellName then
+      SpellIndexCache[spellName] = i
+      _G.DoiteConditions_SpellBookTypeCache[spellName] = BOOKTYPE_PET
       return i
     end
     i = i + 1
   end
 
   SpellIndexCache[spellName] = false
+  _G.DoiteConditions_SpellBookTypeCache[spellName] = false
   return nil
 end
 
@@ -890,7 +909,8 @@ local function _AbilityRemainingByName(spellName)
     return nil
   end
   local idx = _GetSpellIndexByName(spellName)
-  return _AbilityRemainingSeconds(idx, BOOKTYPE_SPELL)
+  local bt = _G.DoiteConditions_SpellBookTypeCache[spellName]
+  return _AbilityRemainingSeconds(idx, bt or BOOKTYPE_SPELL)
 end
 
 -- Cooldown (remaining, totalDuration) by spell name; nil,nil if not in book
@@ -899,11 +919,12 @@ local function _AbilityCooldownByName(spellName)
     return nil, nil
   end
   local idx = _GetSpellIndexByName(spellName)
+  local bt = _G.DoiteConditions_SpellBookTypeCache[spellName]
   if not idx then
     return nil, nil
   end
 
-  local start, dur = GetSpellCooldown(idx, BOOKTYPE_SPELL)
+  local start, dur = GetSpellCooldown(idx, bt or BOOKTYPE_SPELL)
   if start and dur and start > 0 and dur > 0 then
     local rem = (start + dur) - GetTime()
     if rem < 0 then
@@ -4263,8 +4284,9 @@ local function _EnsureAbilityTexture(frame, data)
   end
 
   local idx = _GetSpellIndexByName(spellName)
+  local bt = _G.DoiteConditions_SpellBookTypeCache[spellName]
   if idx then
-    local tex = GetSpellTexture(idx, BOOKTYPE_SPELL)
+    local tex = GetSpellTexture(idx, bt or BOOKTYPE_SPELL)
     if tex then
       frame.icon:SetTexture(tex)
       IconCache[spellName] = tex -- persist
@@ -5030,6 +5052,7 @@ local function CheckAbilityConditions(data)
   ctx.allowSelf = (c.targetSelf == true)
   ctx.spellName = _GetCanonicalSpellNameFromData(data)
   ctx.spellIndex = _GetSpellIndexByName(ctx.spellName)
+  ctx.spellBookType = _G.DoiteConditions_SpellBookTypeCache[ctx.spellName]
   ctx.tf = nil
 
   -- While editing this key, force conditions to pass (always show).
@@ -5087,7 +5110,7 @@ local function CheckAbilityConditions(data)
   -- === 1. Cooldown / usability (MODE-ONLY) ===
   local spellName = ctx.spellName
   local spellIndex = ctx.spellIndex
-  local bookType = BOOKTYPE_SPELL
+  local bookType = ctx.spellBookType or BOOKTYPE_SPELL
   local onCdNow = false
 
   if not spellIndex then
@@ -7864,6 +7887,12 @@ eventFrame:SetScript("OnEvent", function()
     if cache then
       for k in pairs(cache) do
         cache[k] = nil
+      end
+    end
+    local btCache = _G.DoiteConditions_SpellBookTypeCache
+    if btCache then
+      for k in pairs(btCache) do
+        btCache[k] = nil
       end
     end
     dirty_ability = true

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -231,6 +231,12 @@ local function _IsRogueOrDruid()
   return (c == "ROGUE" or c == "DRUID")
 end
 
+local function _IsHunterOrWarlock()
+  local _, c = UnitClass("player")
+  c = c and string.upper(c) or ""
+  return (c == "HUNTER" or c == "WARLOCK")
+end
+
 -- If an aura is ALWAYS applied by the player to the player, ownership is meaningless.
 local DOITE_AURA_OWNER_LOCK_ON_SELF = {
   ["Zeal"] = true, ["Berserker Rage"] = true,
@@ -724,6 +730,10 @@ EnsureDBEntry = function(key)
     end
     if d.conditions.aura.weaponFilter == nil then
       d.conditions.aura.weaponFilter = nil
+    end
+
+    if d.conditions.aura.trackpet == nil then
+      d.conditions.aura.trackpet = false
     end
 
     -- legacy cleanup
@@ -2213,6 +2223,9 @@ local function CreateConditionsUI()
   condFrame.cond_aura_class_note:SetTextColor(1, 0.82, 0)
   condFrame.cond_aura_class_note:SetText("No class-specific option added for your class.")
   condFrame.cond_aura_class_note:Hide()
+
+  condFrame.cond_aura_trackpet = MakeCheck("DoiteCond_Aura_TrackPet", "Track this Aura on pet", 0, auraClassRowY)
+  condFrame.cond_aura_trackpet:Hide()
 
   -- Aura: Sound effects
   condFrame.cond_aura_sound_ongain_cb = MakeCheck("DoiteCond_Aura_Sound_OnGain_CB", "On gain", 0, row14_y - 10)
@@ -4036,6 +4049,23 @@ function UpdateItemStacksForMissing()
     SafeEvaluate()
   end)
 
+  if condFrame.cond_aura_trackpet then
+    condFrame.cond_aura_trackpet:SetScript("OnClick", function()
+      if not currentKey then
+        this:SetChecked(false)
+        return
+      end
+      local d = EnsureDBEntry(currentKey);
+      d.conditions.aura = d.conditions.aura or {}
+      d.conditions.aura.trackpet = this:GetChecked() and true or false
+      if UpdateCondFrameForKey then
+        UpdateCondFrameForKey(currentKey)
+      end
+      SafeRefresh();
+      SafeEvaluate()
+    end)
+  end
+
   -- === Aura Power toggle ===
   condFrame.cond_aura_power:SetScript("OnClick", function()
     if not currentKey then
@@ -5290,6 +5320,9 @@ function UpdateItemStacksForMissing()
   condFrame.cond_aura_fade:Hide()
   condFrame.cond_aura_fade_slider:Hide()
   condFrame.cond_aura_mine:Hide()
+  if condFrame.cond_aura_trackpet then
+    condFrame.cond_aura_trackpet:Hide()
+  end
   if condFrame.cond_aura_others then
     condFrame.cond_aura_others:Hide()
   end
@@ -5633,33 +5666,37 @@ do
   local function AuraCond_BuildAbilitySpellList()
     local spells = {}
     local seen = {}
-    local i = 1
 
-    while true do
-      local name, rank = GetSpellName(i, BOOKTYPE_SPELL)
-      if not name then
-        break
-      end
+    local function scanBook(bookType)
+      local i = 1
+      while true do
+        local name, rank = GetSpellName(i, bookType)
+        if not name then
+          break
+        end
 
-      -- filter out passives
-      local isPassive = false
-      if IsPassiveSpell then
-        local ok, passive = pcall(IsPassiveSpell, i, BOOKTYPE_SPELL)
-        if ok and passive then
+        local isPassive = false
+        if IsPassiveSpell then
+          local ok, passive = pcall(IsPassiveSpell, i, bookType)
+          if ok and passive then
+            isPassive = true
+          end
+        end
+        if (not isPassive) and rank and string.find(rank, "Passive") then
           isPassive = true
         end
-      end
-      if (not isPassive) and rank and string.find(rank, "Passive") then
-        isPassive = true
-      end
 
-      if not isPassive and name and name ~= "" and not seen[name] then
-        table.insert(spells, name)
-        seen[name] = true
-      end
+        if not isPassive and name and name ~= "" and not seen[name] then
+          table.insert(spells, name)
+          seen[name] = true
+        end
 
-      i = i + 1
+        i = i + 1
+      end
     end
+
+    scanBook(BOOKTYPE_SPELL)
+    scanBook(BOOKTYPE_PET)
 
     table.sort(spells, function(a, b)
       a = string.lower(a or "")
@@ -6955,37 +6992,42 @@ do
   local function VfxCond_BuildAbilitySpellList()
     local spells = {}
     local seen = {}
-    local i = 1
-  
-    while true do
-      local name, rank = GetSpellName(i, BOOKTYPE_SPELL)
-      if not name then break end
-  
-      local isPassive = false
-      if IsPassiveSpell then
-        local ok, passive = pcall(IsPassiveSpell, i, BOOKTYPE_SPELL)
-        if ok and passive then
+
+    local function scanBook(bookType)
+      local i = 1
+      while true do
+        local name, rank = GetSpellName(i, bookType)
+        if not name then break end
+
+        local isPassive = false
+        if IsPassiveSpell then
+          local ok, passive = pcall(IsPassiveSpell, i, bookType)
+          if ok and passive then
+            isPassive = true
+          end
+        end
+        if (not isPassive) and rank and string.find(rank, "Passive") then
           isPassive = true
         end
+
+        if not isPassive and name and name ~= "" and not seen[name] then
+          table.insert(spells, name)
+          seen[name] = true
+        end
+
+        i = i + 1
       end
-      if (not isPassive) and rank and string.find(rank, "Passive") then
-        isPassive = true
-      end
-  
-      if not isPassive and name and name ~= "" and not seen[name] then
-        table.insert(spells, name)
-        seen[name] = true
-      end
-  
-      i = i + 1
     end
-  
+
+    scanBook(BOOKTYPE_SPELL)
+    scanBook(BOOKTYPE_PET)
+
     table.sort(spells, function(a, b)
       a = string.lower(a or "")
       b = string.lower(b or "")
       return a < b
     end)
-  
+
     return spells
   end
 
@@ -8339,6 +8381,11 @@ local function UpdateConditionsUI(data)
       condFrame.cond_ability_cp_val:Hide()
       condFrame.cond_ability_cp_val_enter:Hide()
       if condFrame.cond_ability_class_note then
+        if _IsHunterOrWarlock and _IsHunterOrWarlock() then
+          condFrame.cond_ability_class_note:SetText("Pet-tracking option for buff/debuff under this section.")
+        else
+          condFrame.cond_ability_class_note:SetText("No class-specific option added for your class.")
+        end
         condFrame.cond_ability_class_note:Show()
       end
     end
@@ -8516,6 +8563,9 @@ local function UpdateConditionsUI(data)
     end
     if condFrame.cond_aura_class_note then
       condFrame.cond_aura_class_note:Hide()
+    end
+    if condFrame.cond_aura_trackpet then
+      condFrame.cond_aura_trackpet:Hide()
     end
     if condFrame.cond_aura_weaponDD then
       condFrame.cond_aura_weaponDD:Hide()
@@ -9465,6 +9515,11 @@ local ic = c.item or {}
       condFrame.cond_item_cp_val:Hide()
       condFrame.cond_item_cp_val_enter:Hide()
       if condFrame.cond_item_class_note then
+        if _IsHunterOrWarlock and _IsHunterOrWarlock() then
+          condFrame.cond_item_class_note:SetText("Pet-tracking option for buff/debuff under this section.")
+        else
+          condFrame.cond_item_class_note:SetText("No class-specific option added for your class.")
+        end
         condFrame.cond_item_class_note:Show()
       end
     end
@@ -9632,6 +9687,9 @@ local ic = c.item or {}
     if condFrame.cond_aura_class_note then
       condFrame.cond_aura_class_note:Hide()
     end
+    if condFrame.cond_aura_trackpet then
+      condFrame.cond_aura_trackpet:Hide()
+    end
 
   elseif data.type == "Custom" then
     -- Hide all separators – the edit box fills the entire conditions area.
@@ -9746,6 +9804,7 @@ local ic = c.item or {}
     _Hide(condFrame.cond_aura_hp_val_enter)
     _Hide(condFrame.cond_aura_mine)
     _Hide(condFrame.cond_aura_others)
+    _Hide(condFrame.cond_aura_trackpet)
     _Hide(condFrame.cond_aura_owner_tip)
     _Hide(condFrame.cond_aura_remaining_cb)
     _Hide(condFrame.cond_aura_remaining_comp)
@@ -9969,6 +10028,15 @@ local ic = c.item or {}
     condFrame.cond_aura_target_harm:SetChecked(tm)
     condFrame.cond_aura_onself:SetChecked(ts)
 
+    local isTrackPetActive = (_IsHunterOrWarlock and _IsHunterOrWarlock() and c.aura and c.aura.trackpet) and true or false
+    if condFrame.cond_aura_onself and condFrame.cond_aura_onself.text and condFrame.cond_aura_onself.text.SetText then
+      if isTrackPetActive then
+        condFrame.cond_aura_onself.text:SetText("Target (pet)")
+      else
+        condFrame.cond_aura_onself.text:SetText("On player (self)")
+      end
+    end
+
     -- === TARGET DISTANCE & TYPE (Aura) ===
     if condFrame.cond_aura_distanceDD then
       condFrame.cond_aura_distanceDD:Show()
@@ -10098,7 +10166,23 @@ local ic = c.item or {}
       condFrame.cond_aura_cp_val:Hide()
       condFrame.cond_aura_cp_val_enter:Hide()
       if condFrame.cond_aura_class_note then
-        condFrame.cond_aura_class_note:Show()
+        if _IsHunterOrWarlock and _IsHunterOrWarlock() then
+          condFrame.cond_aura_class_note:Hide()
+        else
+          condFrame.cond_aura_class_note:SetText("No class-specific option added for your class.")
+          condFrame.cond_aura_class_note:Show()
+        end
+      end
+    end
+
+    if condFrame.cond_aura_trackpet then
+      local isHW = _IsHunterOrWarlock and _IsHunterOrWarlock() or false
+      if isHW then
+        condFrame.cond_aura_trackpet:Show()
+        condFrame.cond_aura_trackpet:SetChecked((c.aura and c.aura.trackpet) and true or false)
+      else
+        condFrame.cond_aura_trackpet:Hide()
+        condFrame.cond_aura_trackpet:SetChecked(false)
       end
     end
 
@@ -10166,7 +10250,9 @@ local ic = c.item or {}
 
     -- If this aura is in the lock-list AND target is "On player (self)", ownership is meaningless.
     local lockOwnerOnSelf = false
-    if isSelfOnly and DoiteEdit_ShouldLockAuraOwnerOnSelf and DoiteEdit_ShouldLockAuraOwnerOnSelf(data) then
+    if isTrackPetActive then
+      lockOwnerOnSelf = true
+    elseif isSelfOnly and DoiteEdit_ShouldLockAuraOwnerOnSelf and DoiteEdit_ShouldLockAuraOwnerOnSelf(data) then
       lockOwnerOnSelf = true
     end
 
@@ -10246,8 +10332,8 @@ local ic = c.item or {}
       -- === Text: Time remaining ===
       condFrame.cond_aura_text_time:Show()
 
-      if isSelfOnly then
-        -- On Player (self): user may freely toggle Text: Remaining
+      if isTrackPetActive or isSelfOnly then
+        -- Pet-tracking (or On Player self): user may freely toggle Text: Remaining
         DoiteEdit_EnableCheck(condFrame.cond_aura_text_time)
         condFrame.cond_aura_text_time:SetChecked((c.aura and c.aura.textTimeRemaining) or false)
 
@@ -10389,8 +10475,8 @@ local ic = c.item or {}
         condFrame.cond_aura_remaining_cb.text:SetText("Remaining")
       end
 
-      if isSelfOnly then
-        -- On Player (self): user can freely toggle Remaining
+      if isTrackPetActive or isSelfOnly then
+        -- Pet-tracking (or On Player self): user can freely toggle Remaining
         DoiteEdit_EnableCheck(condFrame.cond_aura_remaining_cb)
         condFrame.cond_aura_remaining_cb:SetChecked(aRemEnabled)
 


### PR DESCRIPTION
### Motivation
- Add support for abilities that live in the pet spellbook so textures, cooldowns and dropdown lists work for pet abilities (needed for Hunters/Warlocks and similar setups).
- Persist and use the spellbook type returned by accelerated APIs to avoid incorrect lookups when a spell comes from the pet book.
- Expose a UI option to track auras on a pet and ensure ownership/remaining/time logic behaves correctly when pet-tracking is enabled.

### Description
- Update `DoiteAuras.lua` to scan `BOOKTYPE_PET` in ability dropdowns, have `FindSpellBookSlot` return `(slot, bookType)`, cache the book type, and call `GetSpellTexture` with the correct `bookType` when available.
- Update `Modules/DoiteConditions.lua` to add a global `DoiteConditions_SpellBookTypeCache`, accept `bookType` from `GetSpellSlotTypeIdForName`, scan the pet spellbook as a fallback, and use the cached `bookType` for `GetSpellCooldown`, `GetSpellTexture`, and cooldown/capability checks; also clear the book-type cache on `SPELLS_CHANGED`.
- Update ability lookup helpers (`_GetSpellIndexByName`, `_AbilityRemainingByName`, `_AbilityCooldownByName`, `_EnsureAbilityTexture`, cooldown helpers) to honor the pet `bookType` when present.
- Add pet-tracking UI and defaults in `Modules/DoiteEdit.lua`: new helper `_IsHunterOrWarlock`, new checkbox `cond_aura_trackpet`, default DB field `conditions.aura.trackpet`, click handler, show/hide logic for Hunters/Warlocks, label text changes (`"On player (self)"` -> `"Target (pet)"` when tracking), and treat `trackpet` as locking owner-on-self for ownership and remaining/text rules.
- Mirror the non-passive spellbook scanning changes into aura/vfx ability lists so pet abilities appear in those dropdowns too.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b81867ce90832a83f46013d6898328)