### PR TITLE
Fix intermittent item icon/state desync when bag state flips

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -7962,11 +7962,11 @@ eventFrame:SetScript("OnEvent", function()
 
   elseif event == "BAG_UPDATE" then
     if DoiteConditions and DoiteConditions._hasAnyItemLogic then
-      if GetTime() >= (DoiteConditions._daLastBagInvalidateAt or 0) then
-        if _InvalidateItemScanCache then
-          _InvalidateItemScanCache()
-        end
-        DoiteConditions._daLastBagInvalidateAt = GetTime() + 0.10
+      -- Keep item whereabouts/counts exact when stacks split/merge or the last
+      -- item leaves a bag slot. Throttling this can miss the final state flip
+      -- (bag -> missing) and briefly hide/show wrong icon state.
+      if _InvalidateItemScanCache then
+        _InvalidateItemScanCache()
       end
       dirty_ability = true
     end


### PR DESCRIPTION
### Motivation
- Event-side invalidation of the item-scan cache was being throttled on `BAG_UPDATE`, which can miss the final transition when stacks split/merge or the last item is removed and cause brief wrong icon visibility or stack text.
- The change aims to ensure item whereabouts/counts are exact at the moment `BAG_UPDATE` fires while avoiding touching other cooldown-related throttles.

### Description
- Always call `_InvalidateItemScanCache()` on every `BAG_UPDATE` when item logic is active, instead of using the previous 0.10s throttle, in `Modules/DoiteConditions.lua`.
- Added explanatory comment about the race (stack split/merge and last-item transitions) and left `BAG_UPDATE_COOLDOWN` throttling unchanged.
- Change is limited to event invalidation timing and does not modify condition math, rendering, or scan algorithms.

### Testing
- Verified the file change and diff with `git diff` and `git status` which showed `Modules/DoiteConditions.lua` modified and ready to commit (succeeded).
- Committed the change with `git commit` (succeeded).
- Attempted to validate parsing with `lua -e "assert(loadfile('Modules/DoiteConditions.lua'))"` but the `lua` binary is not available in this environment, so a local parse check could not be performed.
- Created the PR record (automated `make_pr` invocation) with the matching title/body (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b86bcce8b4832aaa72abefe844fc5d)