### PR TITLE
Support spell ID input in extra aura/VFX conditions

### DIFF
--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -5882,6 +5882,38 @@ do
     local namePart = white .. prefix .. (niceName or "") .. "|r"
     return typePart .. " " .. sep .. modePart .. " " .. sep .. unitPart .. ": " .. namePart
   end
+
+  local function AuraCond_ParseAuraInput(rawText)
+    local text = string.gsub(rawText or "", "^%s*(.-)%s*$", "%1")
+    if text == "" then
+      return nil
+    end
+
+    local sid = tonumber(text)
+    if sid and sid > 0 then
+      local sidStr = tostring(sid)
+      local displayName = sidStr
+
+      if type(GetSpellNameAndRankForId) == "function" then
+        local ok, sn = pcall(GetSpellNameAndRankForId, sid)
+        if ok and sn and sn ~= "" then
+          displayName = tostring(sn)
+        end
+      end
+
+      return {
+        name = displayName,
+        spellid = sidStr,
+        Addedviaspellid = true,
+      }
+    end
+
+    return {
+      name = AuraCond_TitleCase(text),
+      spellid = nil,
+      Addedviaspellid = nil,
+    }
+  end
   
   -- Only update stacks widget visibility + Continue enabled-state.
   -- IMPORTANT: This does NOT rebuild the whole row, so the editbox keeps focus.
@@ -6263,8 +6295,8 @@ do
     else
       text = row.editBox and row.editBox:GetText() or ""
     end
-    text = string.gsub(text or "", "^%s*(.-)%s*$", "%1")
-    if text == "" then
+    local parsedInput = AuraCond_ParseAuraInput(text)
+    if not parsedInput then
       return
     end
 
@@ -6291,7 +6323,9 @@ do
 	  buffType = buffType,
 	  mode = mode,
       unit = unit,
-	  name = AuraCond_TitleCase(text),
+	  name = parsedInput.name,
+	  spellid = parsedInput.spellid,
+	  Addedviaspellid = parsedInput.Addedviaspellid,
 	}
 
 	-- only for aura (buff/debuff), store optional stack settings
@@ -6956,6 +6990,38 @@ do
     return typePart .. " " .. sep .. modePart .. " " .. sep .. unitPart .. ": " .. namePart
   end
 
+  local function VfxCond_ParseAuraInput(rawText)
+    local text = string.gsub(rawText or "", "^%s*(.-)%s*$", "%1")
+    if text == "" then
+      return nil
+    end
+
+    local sid = tonumber(text)
+    if sid and sid > 0 then
+      local sidStr = tostring(sid)
+      local displayName = sidStr
+
+      if type(GetSpellNameAndRankForId) == "function" then
+        local ok, sn = pcall(GetSpellNameAndRankForId, sid)
+        if ok and sn and sn ~= "" then
+          displayName = tostring(sn)
+        end
+      end
+
+      return {
+        name = displayName,
+        spellid = sidStr,
+        Addedviaspellid = true,
+      }
+    end
+
+    return {
+      name = VfxCond_TitleCase(text),
+      spellid = nil,
+      Addedviaspellid = nil,
+    }
+  end
+
   local VfxCond_RowCounter = 0
 
   -- Small helper to reopen the dropdown a frame later
@@ -7560,8 +7626,8 @@ do
 	else
 	  text = row.editBox and row.editBox:GetText() or ""
 	end
-	text = string.gsub(text or "", "^%s*(.-)%s*$", "%1")
-	if text == "" then return end
+	local parsedInput = VfxCond_ParseAuraInput(text)
+	if not parsedInput then return end
 
     local buffType = row._choiceBuffType or "BUFF"
     local mode = row._choiceMode or "found"
@@ -7586,7 +7652,9 @@ do
 	  buffType = buffType,
 	  mode = mode,
 	  unit = unit,
-	  name = VfxCond_TitleCase(text),
+	  name = parsedInput.name,
+	  spellid = parsedInput.spellid,
+	  Addedviaspellid = parsedInput.Addedviaspellid,
 	  fade = nil,
 	  fadeAlpha = 0,
 	}


### PR DESCRIPTION
### Motivation
- Extra Aura and VFX condition builders treated numeric buff/debuff input as a literal name, preventing exact spell-ID matching logic (remaining time / stacks / ownership) from being used when users paste spell IDs.

### Description
- Added `AuraCond_ParseAuraInput` and `VfxCond_ParseAuraInput` to canonicalize edit-box input and detect pure-numeric spell ID input, resolving a display name via `GetSpellNameAndRankForId` when available.
- Updated the extra Aura condition `OnAdd` flow to use the parsed input and persist `name`, `spellid`, and `Addedviaspellid` when numeric input is detected so the evaluation path uses exact-ID matching.
- Applied the same parsing and persistence changes to the extra VFX condition `OnAdd` flow so VFX conditions follow identical spell-ID semantics.
- Left non-numeric (name) behavior unchanged and preserved stack handling semantics for aura entries.

### Testing
- Verified the code changes and patch scope via `git diff` and `git status` and committed the update successfully (commit message: "Support spell ID input for extra aura and VFX conditions").
- Attempted a Lua syntax check with `luac -p Modules/DoiteEdit.lua`, but the `luac` binary was not available in the environment so the check could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b8735e8584832a9a6a70ed4f90b0be)