### PR TITLE
Simplify aura ownership logic and adjust rogue duration/talent handling

### DIFF
--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -237,25 +237,6 @@ local function _IsHunterOrWarlock()
   return (c == "HUNTER" or c == "WARLOCK")
 end
 
--- If an aura is ALWAYS applied by the player to the player, ownership is meaningless.
-local DOITE_AURA_OWNER_LOCK_ON_SELF = {
-  ["Zeal"] = true, ["Berserker Rage"] = true,
-}
-
-local function DoiteEdit_ShouldLockAuraOwnerOnSelf(data)
-  if not data then
-    return false
-  end
-  local name = data.displayName or currentKey
-  if not name or name == "" then
-    name = currentKey
-  end
-  if not name then
-    return false
-  end
-  return DOITE_AURA_OWNER_LOCK_ON_SELF[name] == true
-end
-
 local function DoiteEdit_YellowifyButton(btn)
   if not btn then
     return
@@ -10969,11 +10950,11 @@ local ic = c.item or {}
       end
     end
 
-    -- If this aura is in the lock-list AND target is "On player (self)", ownership is meaningless.
+    -- If target is "On player (self)", ownership is meaningless.
     local lockOwnerOnSelf = false
     if isTrackPetActive then
       lockOwnerOnSelf = true
-    elseif isSelfOnly and DoiteEdit_ShouldLockAuraOwnerOnSelf and DoiteEdit_ShouldLockAuraOwnerOnSelf(data) then
+    elseif isSelfOnly then
       lockOwnerOnSelf = true
     end
 

--- a/Modules/DoiteTrack.lua
+++ b/Modules/DoiteTrack.lua
@@ -39,22 +39,10 @@ local ManualDurationBySpellId = {
   [11275] = { [1]=8,[2]=10,[3]=12,[4]=14,[5]=16 }, -- Rupture Rank 6
   
   ----------------------------------------------------------------
-  -- Taste for Blood (2 ranks) - CP based
-  ----------------------------------------------------------------
-  [52528] = { [1]=12,[2]=14,[3]=16,[4]=18,[5]=20 }, -- Taste for Blood Rank 1
-  [52529] = { [1]=14,[2]=16,[3]=18,[4]=20,[5]=22 }, -- Taste for Blood Rank 2
-
-  ----------------------------------------------------------------
   -- Kidney Shot (2 ranks) - CP based
   ----------------------------------------------------------------
   [408] = { [1]=1,[2]=2,[3]=3,[4]=4,[5]=5 }, -- Kidney Shot Rank 1
   [8643] = { [1]=2,[2]=3,[3]=4,[4]=5,[5]=6 }, -- Kidney Shot Rank 2
-  
-  ----------------------------------------------------------------
-  -- Slice and Dice (2 ranks) - CP based
-  ----------------------------------------------------------------
-  [5171] = { [1]=9,[2]=12,[3]=15,[4]=18,[5]=21 }, -- Slice and Dice Rank 1
-  [6774] = { [1]=9,[2]=12,[3]=15,[4]=18,[5]=21 }, -- Slice and Dice Rank 2
   
   ----------------------------------------------------------------
   -- Envenom (1 ranks) - CP based
@@ -275,7 +263,8 @@ local function _AddTrackedFromEntry(_, data)
   end
 
 
-  local hasTarget = (c.targetSelf or c.targetHelp or c.targetHarm)
+  -- Ownership tracking is only meaningful for external targets.
+  local hasTarget = (c.targetHelp or c.targetHarm)
   if not hasTarget then
     return
   end
@@ -311,7 +300,6 @@ local function _AddTrackedFromEntry(_, data)
       name = name,
       normName = norm,
       kind = data.type,
-      trackSelf = false,
       trackHelp = false,
       trackHarm = false,
       onlyMine = false,
@@ -330,9 +318,6 @@ local function _AddTrackedFromEntry(_, data)
     TrackedByNameNorm[norm] = entry
   end
 
-  if c.targetSelf then
-    entry.trackSelf = true
-  end
   if c.targetHelp then
     entry.trackHelp = true
   end
@@ -623,8 +608,7 @@ local _MoltenBlastSpellIdCache = {} -- [spellId] = true/false
 _IsPlayerDruid = false
 _IsPlayerRogue = false
 local _CarnageRank = 0             -- druid: >0 enables Carnage proc logic
-local _TasteForBloodRank = 0       -- rogue: 0..2, adds +2s per point to manual Rupture
-local _ImprovedBladeTacticsRank = 0 -- rogue: 0..3, +15/30/45% to Slice and Dice manual duration
+local _TasteForBloodRank = 0       -- rogue: 0..2, manual Rupture +4s at rank1, +6s at rank2
 
 -- Druid Carnage proc detection
 local _FerociousBiteSpellIdCache = {} -- [spellId] = true/false
@@ -687,7 +671,6 @@ end
 local function _UpdateTalentCaches()
   _CarnageRank = 0
   _TasteForBloodRank = 0
-  _ImprovedBladeTacticsRank = 0
 
   if not UnitClass then
     _IsPlayerDruid = false
@@ -710,7 +693,6 @@ local function _UpdateTalentCaches()
 
   local needCarnage = _IsPlayerDruid
   local needTaste = _IsPlayerRogue
-  local needBlade = _IsPlayerRogue
 
   local numTabs = tonumber(GetNumTalentTabs()) or 0
   local tab
@@ -729,11 +711,7 @@ local function _UpdateTalentCaches()
           _TasteForBloodRank = tonumber(rank) or 0
           needTaste = false
         end
-        if needBlade and norm == "improved blade tactics" then
-          _ImprovedBladeTacticsRank = tonumber(rank) or 0
-          needBlade = false
-        end
-        if (not needCarnage) and (not needTaste) and (not needBlade) then
+        if (not needCarnage) and (not needTaste) then
           return
         end
       end
@@ -1621,18 +1599,13 @@ function DoiteTrack:_OnSpellCastEvent()
     return
   end
 
-  -- Resolve target: self-only -> player, else must be real target
-  local selfOnly = (entry.trackSelf and (not entry.trackHelp) and (not entry.trackHarm))
-  if selfOnly then
-    targetGuid = pGuid
-  else
-    if _IsBadGuid(targetGuid) then
-      local tg = _GetUnitGuidSafe("target")
-      if not tg or tg == "" then
-        return
-      end
-      targetGuid = tg
+  -- Resolve target from NP event, fallback to current target.
+  if _IsBadGuid(targetGuid) then
+    local tg = _GetUnitGuidSafe("target")
+    if not tg or tg == "" then
+      return
     end
+    targetGuid = tg
   end
 
   -- Only snapshot CP if this spellId has a CP-table manual entry
@@ -2017,8 +1990,6 @@ function DoiteTrack:_OnAuraNPEvent()
 
     if event == "AURA_CAST_ON_SELF" then
       selfOnly = true
-    elseif entry then
-      selfOnly = (entry.trackSelf and (not entry.trackHelp) and (not entry.trackHarm))
     end
 
     if selfOnly then
@@ -2078,18 +2049,15 @@ function DoiteTrack:_OnAuraNPEvent()
     if cp and cp > 0 then
       manualSec = _GetManualDurationBySpellId(spellId, cp)
 
-      -- Rogue SC: Taste for Blood increases Rupture duration by +2s per talent point.
+      -- Rogue SC: Taste for Blood increases Rupture duration:
+      -- rank 1 => +4s, rank 2 => +6s total.
       if manualSec and manualSec > 0 and _IsPlayerRogue and _TasteForBloodRank and _TasteForBloodRank > 0 then
         if spellNameNorm == "rupture" then
-          manualSec = manualSec + (_TasteForBloodRank * 2)
-        end
-      end
-
-      -- Rogue SC: Improved Blade Tactics increases Slice and Dice duration by +15%/+30%/+45%. Apply to the *manual* CP-table duration (same place as Rupture edge case).
-      if manualSec and manualSec > 0 and _IsPlayerRogue and _ImprovedBladeTacticsRank and _ImprovedBladeTacticsRank > 0 then
-        if spellNameNorm == "slice and dice" then
-          local pct = _ImprovedBladeTacticsRank * 15
-          manualSec = math.floor((manualSec * (100 + pct)) / 100 + 0.5)
+          if _TasteForBloodRank >= 2 then
+            manualSec = manualSec + 6
+          else
+            manualSec = manualSec + 4
+          end
         end
       end
     end


### PR DESCRIPTION
### Motivation

- Remove brittle special-case locking of aura ownership and simplify rules so ownership is considered meaningless whenever the target is the player (self) or tracking a pet is active.
- Stop treating self-targeted tracking entries as ownership-tracked items because ownership is only meaningful for external targets.
- Correct and simplify rogue manual-duration logic for Rupture/Taste for Blood and remove outdated Slice and Dice / Improved Blade Tactics handling.

### Description

- Removed the `DOITE_AURA_OWNER_LOCK_ON_SELF` table and `DoiteEdit_ShouldLockAuraOwnerOnSelf` helper, and simplified the owner-locking branch to lock whenever the target is self or pet-tracking is active in `DoiteEdit.lua`.
- Changed ownership-tracking semantics in `DoiteTrack.lua` so `targetSelf` is no longer treated as a tracked target when deciding whether to add an entry, and removed the `trackSelf` field from tracked entries.
- Simplified target resolution logic when spell/aura events provide invalid GUIDs to always fall back to the current target (with `AURA_CAST_ON_SELF` still forcing self), and removed code paths relying on `entry.trackSelf`.
- Removed manual duration table entries for `Taste for Blood` and `Slice and Dice`, removed `_ImprovedBladeTacticsRank` handling and talent lookup, and updated `Taste for Blood` behavior to add +4s at rank 1 and +6s at rank 2 when calculating manual Rupture duration.

### Testing

- Ran static Lua checks (`luacheck` style parsing) against modified files with no syntax errors reported.
- Executed the repository's automated unit/integration test suite and CI checks where available, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c3b42dc154832abf6d61098d3c0609)