### PR TITLE
Replace remaining DoiteBars default edit boxes with custom bordered edit boxes

### DIFF
--- a/Modules/DoiteBars.lua
+++ b/Modules/DoiteBars.lua
@@ -852,6 +852,28 @@ end
 ---------------------------------------------------------------
 -- Slider helper; parents to a given frame, mirrors MakeSlider
 ---------------------------------------------------------------
+local function BE_StylePlainEditBox(editBox, justify)
+    if not editBox then return end
+    editBox:SetAutoFocus(false)
+    editBox:SetFontObject("GameFontNormalSmall")
+    editBox:SetJustifyH(justify or "CENTER")
+    if editBox.SetTextInsets then
+        editBox:SetTextInsets(6, 6, 0, 0)
+    end
+    if editBox.SetBackdrop then
+        editBox:SetBackdrop({
+            bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+            edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+            tile = true,
+            tileSize = 16,
+            edgeSize = 12,
+            insets = { left = 3, right = 3, top = 3, bottom = 3 }
+        })
+        editBox:SetBackdropColor(0, 0, 0, 0.85)
+        editBox:SetBackdropBorderColor(0.6, 0.6, 0.6, 1)
+    end
+end
+
 local function BE_MakeSlider(parent, name, text, x, y, width, minVal, maxVal, step)
     local s = CreateFrame("Slider", name, parent, "OptionsSliderTemplate")
     s:SetWidth(width)
@@ -867,13 +889,11 @@ local function BE_MakeSlider(parent, name, text, x, y, width, minVal, maxVal, st
     if low  then low:SetText(tostring(minVal));  low:SetFontObject("GameFontNormalSmall") end
     if high then high:SetText(tostring(maxVal)); high:SetFontObject("GameFontNormalSmall") end
 
-    local eb = CreateFrame("EditBox", name .. "_EditBox", parent, "InputBoxTemplate")
+    local eb = CreateFrame("EditBox", name .. "_EditBox", parent)
     eb:SetWidth(38); eb:SetHeight(18)
     eb:SetPoint("TOP", s, "BOTTOM", 3, -8)
-    eb:SetAutoFocus(false)
     eb:SetText("0")
-    eb:SetJustifyH("CENTER")
-    eb:SetFontObject("GameFontNormalSmall")
+    BE_StylePlainEditBox(eb, "CENTER")
     eb.slider    = s
     eb._updating = false
 
@@ -1270,11 +1290,10 @@ local function BE_PopulateContent(content, key)
             BE_RefreshEditedBar()
         end
     end)
-    refs.powerValBox = CreateFrame("EditBox", nil, content, "InputBoxTemplate")
+    refs.powerValBox = CreateFrame("EditBox", nil, content)
     refs.powerValBox:SetWidth(40); refs.powerValBox:SetHeight(18)
     refs.powerValBox:SetPoint("TOPLEFT", content, "TOPLEFT", baseX + 160, y - 2)
-    refs.powerValBox:SetAutoFocus(false)
-    refs.powerValBox:SetJustifyH("CENTER")
+    BE_StylePlainEditBox(refs.powerValBox, "CENTER")
     refs.powerValBox:SetTextColor(1, 0.82, 0)
     refs.powerValBox:SetText(tostring(tonumber(data.powerValue) or 0))
     refs.powerPctLabel = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
@@ -1337,11 +1356,10 @@ local function BE_PopulateContent(content, key)
         end
     end)
 
-    refs.hpValBox = CreateFrame("EditBox", nil, content, "InputBoxTemplate")
+    refs.hpValBox = CreateFrame("EditBox", nil, content)
     refs.hpValBox:SetWidth(40); refs.hpValBox:SetHeight(18)
     refs.hpValBox:SetPoint("TOPLEFT", content, "TOPLEFT", baseX + 220, y - 2)
-    refs.hpValBox:SetAutoFocus(false)
-    refs.hpValBox:SetJustifyH("CENTER")
+    BE_StylePlainEditBox(refs.hpValBox, "CENTER")
     refs.hpValBox:SetTextColor(1, 0.82, 0)
     refs.hpValBox:SetText(tostring(tonumber(data.hpValue) or 0))
     refs.hpPctLabel = content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")


### PR DESCRIPTION
### Motivation
- The remaining `InputBoxTemplate` edit boxes in `DoiteBars` break visually when rows are dynamically positioned, so they need to use the same explicit custom framed editbox style used elsewhere to keep full borders and consistent appearance.
- Consolidate styling into a reusable helper so future editboxes in this module get identical inset/backdrop/font behavior.

### Description
- Added a reusable helper `BE_StylePlainEditBox(editBox, justify)` in `Modules/DoiteBars.lua` that applies backdrop, border, text insets, font, and autofocus/justification settings to an `EditBox`.
- Replaced the slider numeric editbox creation to use `CreateFrame("EditBox", name .. "_EditBox", parent)` (no `InputBoxTemplate`) and applied `BE_StylePlainEditBox` to it so its border stays intact during dynamic layout changes.
- Replaced the Power% and HP% value inputs to use explicit `CreateFrame("EditBox", ..., parent)` instances and applied `BE_StylePlainEditBox` to those fields as well, preserving existing size, positioning, and input handlers.

### Testing
- Confirmed there are no remaining `InputBoxTemplate` usages in `Modules/DoiteBars.lua` by running a targeted ripgrep search for `InputBoxTemplate` and `BE_StylePlainEditBox` which found the new helper and its usages.
- Attempted a Lua syntax check with `luac -p Modules/DoiteBars.lua` but it could not be run because `luac` is not installed in this environment.
- Performed a local diff inspection of `Modules/DoiteBars.lua` to verify the new helper and replacements were inserted without altering the surrounding logic, and the changed editboxes retain their existing event handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ccd6b91bb0832a8cd63c283d4dcd3d)