### PR TITLE
Introduce DoiteTargetAuras module and migrate target-aura logic from conditions

### DIFF
--- a/DoiteAuras.toc
+++ b/DoiteAuras.toc
@@ -16,6 +16,6 @@ Modules\DoiteConditions.lua
 Modules\DoiteGroup.lua
 Modules\DoiteLogic.lua
 Modules\DoiteExport.lua
-Modules\DoiteTrack.lua
+Modules\DoiteTargetAuras.lua
 Modules\DoiteSettings.lua
 Modules\DoiteBars.lua

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2728,86 +2728,53 @@ end
 
 -- For debuff checks only: if all debuff slots are full and the name exists in buffs, treat it as a debuff hit
 local function _TargetHasOverflowDebuff(auraName)
-  if not auraName then
+  if not DoiteTargetAuras or not DoiteTargetAuras.HasDebuff then
     return false
   end
-
-  local snap = auraSnapshot["target"]
-  if not snap then
-    return false
-  end
-
-  local debuffs = snap.debuffs
-  if debuffs and debuffs[auraName] == true then
-    return true
-  end
-
-  local count = snap.debuffCount or 0
-  if count < 16 then
-    -- Debuff bar not "full", so don't risk treating a real buff as debuff.
-    return false
-  end
-
-  local buffs = snap.buffs
-  if buffs and buffs[auraName] == true then
-    return true
-  end
-
-  return false
+  return DoiteTargetAuras.HasDebuff(auraName)
 end
 
 local function _TargetHasAura(auraName, wantDebuff)
-  local unit = "target"
-
-  if not unit or not auraName or not UnitExists(unit) then
+  if not auraName or not UnitExists("target") then
     return false
   end
-
-  local snap = auraSnapshot[unit]
-  if not snap then
+  if not DoiteTargetAuras then
     return false
   end
 
   if wantDebuff then
-    -- Debuff checks: first real debuffs, then overflow in buffs.
-    return _TargetHasOverflowDebuff(auraName)
-  else
-    local b = snap.buffs
-    return b and b[auraName] == true
+    if DoiteTargetAuras.HasDebuff then
+      return DoiteTargetAuras.HasDebuff(auraName)
+    end
+    return false
   end
-end
 
+  if DoiteTargetAuras.HasBuff then
+    return DoiteTargetAuras.HasBuff(auraName)
+  end
+  return false
+end
 
 local function _TargetHasAuraBySpellId(spellId, wantDebuff)
   spellId = tonumber(spellId) or 0
   if spellId <= 0 then
     return false
   end
-
-  local snap = auraSnapshot["target"]
-  if not snap then
+  if not DoiteTargetAuras then
     return false
   end
 
   if wantDebuff then
-    local d = snap.debuffIds
-    if d and d[spellId] then
-      return true
+    if DoiteTargetAuras.HasDebuffSpellId then
+      return DoiteTargetAuras.HasDebuffSpellId(spellId)
     end
-
-    local count = snap.debuffCount or 0
-    if count >= 16 then
-      local b = snap.buffIds
-      if b and b[spellId] then
-        return true
-      end
-    end
-
     return false
   end
 
-  local b = snap.buffIds
-  return b and b[spellId] == true
+  if DoiteTargetAuras.HasBuffSpellId then
+    return DoiteTargetAuras.HasBuffSpellId(spellId)
+  end
+  return false
 end
 
 -- Talent helpers for auraConditions (Known / Not known)
@@ -3192,6 +3159,32 @@ _GetAuraStacksOnUnit = function(unit, auraName, wantDebuff, auraSpellId, addedVi
     end
   end
 
+  if unit == "target" then
+    if not DoiteTargetAuras then
+      return nil
+    end
+
+    if addedViaSpellId == true then
+      local sid = tonumber(auraSpellId) or 0
+      if sid <= 0 then
+        return nil
+      end
+      if wantDebuff and DoiteTargetAuras.GetDebuffStacksBySpellId then
+        return DoiteTargetAuras.GetDebuffStacksBySpellId(sid)
+      elseif (not wantDebuff) and DoiteTargetAuras.GetBuffStacksBySpellId then
+        return DoiteTargetAuras.GetBuffStacksBySpellId(sid)
+      end
+      return nil
+    end
+
+    if wantDebuff and DoiteTargetAuras.GetDebuffStacks then
+      return DoiteTargetAuras.GetDebuffStacks(auraName)
+    elseif (not wantDebuff) and DoiteTargetAuras.GetBuffStacks then
+      return DoiteTargetAuras.GetBuffStacks(auraName)
+    end
+    return nil
+  end
+
   -- TODO improve logic for other units
   ----------------------------------------------------------------
   -- Primary scan: normal BUFF / DEBUFF list for non-player units
@@ -3282,15 +3275,13 @@ local function _TargetHasAnyBuffName(names)
     return false
   end
 
-  local snap = auraSnapshot[unit]
-  local b = snap and snap.buffs
-  if not b then
+  if not DoiteTargetAuras or not DoiteTargetAuras.HasBuff then
     return false
   end
 
   local n = table.getn(names)
   for i = 1, n do
-    if b[names[i]] then
+    if DoiteTargetAuras.HasBuff(names[i]) then
       return true
     end
   end

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2726,14 +2726,6 @@ local function _DoiteTrackRemainingPass(spellKey, unit, comp, threshold, useSpel
   return nil
 end
 
--- For debuff checks only: if all debuff slots are full and the name exists in buffs, treat it as a debuff hit
-local function _TargetHasOverflowDebuff(auraName)
-  if not DoiteTargetAuras or not DoiteTargetAuras.HasDebuff then
-    return false
-  end
-  return DoiteTargetAuras.HasDebuff(auraName)
-end
-
 local function _TargetHasAura(auraName, wantDebuff)
   if not auraName or not UnitExists("target") then
     return false
@@ -6018,25 +6010,22 @@ local function CheckAuraConditions(data)
         found = true
       end
     else
-      local s = auraSnapshot.target
-      if s then
-        local hit = false
-        if useSpellIdOnly and auraSpellId > 0 then
-          if wantBuff and s.buffIds and s.buffIds[auraSpellId] then
-            hit = true
-          elseif wantDebuff and _TargetHasAuraBySpellId(auraSpellId, true) then
-            hit = true
-          end
-        else
-          if wantBuff and s.buffs[name] then
-            hit = true
-          elseif wantDebuff and _TargetHasOverflowDebuff(name) then
-            hit = true
-          end
+      local hit = false
+      if useSpellIdOnly and auraSpellId > 0 then
+        if wantBuff and _TargetHasAuraBySpellId(auraSpellId, false) then
+          hit = true
+        elseif wantDebuff and _TargetHasAuraBySpellId(auraSpellId, true) then
+          hit = true
         end
-        if hit then
-          found = true
+      else
+        if wantBuff and _TargetHasAura(name, false) then
+          hit = true
+        elseif wantDebuff and _TargetHasAura(name, true) then
+          hit = true
         end
+      end
+      if hit then
+        found = true
       end
     end
   end
@@ -6047,25 +6036,22 @@ local function CheckAuraConditions(data)
         found = true
       end
     else
-      local s = auraSnapshot.target
-      if s then
-        local hit = false
-        if useSpellIdOnly and auraSpellId > 0 then
-          if wantBuff and s.buffIds and s.buffIds[auraSpellId] then
-            hit = true
-          elseif wantDebuff and _TargetHasAuraBySpellId(auraSpellId, true) then
-            hit = true
-          end
-        else
-          if wantBuff and s.buffs[name] then
-            hit = true
-          elseif wantDebuff and _TargetHasOverflowDebuff(name) then
-            hit = true
-          end
+      local hit = false
+      if useSpellIdOnly and auraSpellId > 0 then
+        if wantBuff and _TargetHasAuraBySpellId(auraSpellId, false) then
+          hit = true
+        elseif wantDebuff and _TargetHasAuraBySpellId(auraSpellId, true) then
+          hit = true
         end
-        if hit then
-          found = true
+      else
+        if wantBuff and _TargetHasAura(name, false) then
+          hit = true
+        elseif wantDebuff and _TargetHasAura(name, true) then
+          hit = true
         end
+      end
+      if hit then
+        found = true
       end
     end
   end

--- a/Modules/DoiteTargetAuras.lua
+++ b/Modules/DoiteTargetAuras.lua
@@ -1,12 +1,14 @@
 ---------------------------------------------------------------
--- DoiteTrack.lua
+-- DoiteTargetAuras.lua
 -- Aura duration + runtime remaining-time API
 -- Please respect license note: Ask permission
 -- WoW 1.12 | Lua 5.0
 ---------------------------------------------------------------
 
-local DoiteTrack = {}
-_G["DoiteTrack"] = DoiteTrack
+local DoiteTargetAuras = {}
+_G["DoiteTargetAuras"] = DoiteTargetAuras
+_G["DoiteTrack"] = DoiteTargetAuras
+local DoiteTrack = DoiteTargetAuras
 
 ---------------------------------------------------------------
 -- Globals / config overrides
@@ -2636,6 +2638,245 @@ function DoiteTrack:GetAuraOwnershipBySpellId(spellId, unit)
   return nil, false, spellId, false, true, true
 end
 
+
+
+---------------------------------------------------------------
+-- Target aura presence/stacks cache (shared with condition checks)
+---------------------------------------------------------------
+local function _WipeBoolTable(t)
+  local k
+  for k in pairs(t) do
+    t[k] = nil
+  end
+end
+
+local function _EnsureTargetAuraCacheFresh()
+  local c = DoiteTrack._targetAuraCache
+  if not c then
+    c = {
+      stamp = -1,
+      buffCount = 0,
+      debuffCount = 0,
+      buffsByName = {},
+      debuffsByName = {},
+      buffsById = {},
+      debuffsById = {},
+      buffStacksByName = {},
+      debuffStacksByName = {},
+      buffStacksById = {},
+      debuffStacksById = {}
+    }
+    DoiteTrack._targetAuraCache = c
+  end
+
+  if not _UnitExistsFlag("target") then
+    c.stamp = -1
+    c.buffCount = 0
+    c.debuffCount = 0
+    _WipeBoolTable(c.buffsByName)
+    _WipeBoolTable(c.debuffsByName)
+    _WipeBoolTable(c.buffsById)
+    _WipeBoolTable(c.debuffsById)
+    _WipeBoolTable(c.buffStacksByName)
+    _WipeBoolTable(c.debuffStacksByName)
+    _WipeBoolTable(c.buffStacksById)
+    _WipeBoolTable(c.debuffStacksById)
+    return c
+  end
+
+  local now = math.floor(((GetTime and GetTime()) or 0) * 20)
+  if c.stamp == now then
+    return c
+  end
+
+  c.stamp = now
+  c.buffCount = 0
+  c.debuffCount = 0
+  _WipeBoolTable(c.buffsByName)
+  _WipeBoolTable(c.debuffsByName)
+  _WipeBoolTable(c.buffsById)
+  _WipeBoolTable(c.debuffsById)
+  _WipeBoolTable(c.buffStacksByName)
+  _WipeBoolTable(c.debuffStacksByName)
+  _WipeBoolTable(c.buffStacksById)
+  _WipeBoolTable(c.debuffStacksById)
+
+  local auraSpellIds = nil
+  local auraStacks = nil
+  if GetUnitField then
+    local okIds, ids = pcall(GetUnitField, "target", "aura")
+    if okIds and type(ids) == "table" then
+      auraSpellIds = ids
+    end
+    local okStacks, stacks = pcall(GetUnitField, "target", "auraApplications")
+    if okStacks and type(stacks) == "table" then
+      auraStacks = stacks
+    end
+  end
+
+  local i
+  for i = 1, 32 do
+    local sid = tonumber(auraSpellIds and auraSpellIds[i]) or 0
+    if sid > 0 then
+      local stacks = tonumber(auraStacks and auraStacks[i])
+      stacks = (stacks and (stacks + 1)) or 1
+      local nm = _GetSpellNameRank and _GetSpellNameRank(sid)
+      c.buffCount = c.buffCount + 1
+      c.buffsById[sid] = true
+      c.buffStacksById[sid] = stacks
+      if nm and nm ~= "" then
+        c.buffsByName[nm] = true
+        c.buffStacksByName[nm] = stacks
+      end
+    end
+  end
+
+  for i = 1, 16 do
+    local idx = 32 + i
+    local sid = tonumber(auraSpellIds and auraSpellIds[idx]) or 0
+    if sid > 0 then
+      local stacks = tonumber(auraStacks and auraStacks[idx])
+      stacks = (stacks and (stacks + 1)) or 1
+      local nm = _GetSpellNameRank and _GetSpellNameRank(sid)
+      c.debuffCount = c.debuffCount + 1
+      c.debuffsById[sid] = true
+      c.debuffStacksById[sid] = stacks
+      if nm and nm ~= "" then
+        c.debuffsByName[nm] = true
+        c.debuffStacksByName[nm] = stacks
+      end
+    end
+  end
+
+  return c
+end
+
+function DoiteTrack.HasBuff(spellName)
+  if not spellName or spellName == "" then
+    return false
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  return c and c.buffsByName[spellName] or false
+end
+
+function DoiteTrack.HasBuffSpellId(spellId)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return false
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  return c and c.buffsById[spellId] or false
+end
+
+function DoiteTrack.HasDebuff(spellName)
+  if not spellName or spellName == "" then
+    return false
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  if not c then
+    return false
+  end
+  if c.debuffsByName[spellName] then
+    return true
+  end
+  if c.debuffCount >= 16 then
+    return c.buffsByName[spellName] or false
+  end
+  return false
+end
+
+function DoiteTrack.HasDebuffSpellId(spellId)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return false
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  if not c then
+    return false
+  end
+  if c.debuffsById[spellId] then
+    return true
+  end
+  if c.debuffCount >= 16 then
+    return c.buffsById[spellId] or false
+  end
+  return false
+end
+
+function DoiteTrack.GetBuffStacks(spellName)
+  if not spellName or spellName == "" then
+    return nil
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  return c and c.buffStacksByName[spellName] or nil
+end
+
+function DoiteTrack.GetBuffStacksBySpellId(spellId)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return nil
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  return c and c.buffStacksById[spellId] or nil
+end
+
+function DoiteTrack.GetDebuffStacks(spellName)
+  if not spellName or spellName == "" then
+    return nil
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  if not c then
+    return nil
+  end
+  if c.debuffStacksByName[spellName] then
+    return c.debuffStacksByName[spellName]
+  end
+  if c.debuffCount >= 16 then
+    return c.buffStacksByName[spellName]
+  end
+  return nil
+end
+
+function DoiteTrack.GetDebuffStacksBySpellId(spellId)
+  spellId = tonumber(spellId) or 0
+  if spellId <= 0 then
+    return nil
+  end
+  local c = _EnsureTargetAuraCacheFresh()
+  if not c then
+    return nil
+  end
+  if c.debuffStacksById[spellId] then
+    return c.debuffStacksById[spellId]
+  end
+  if c.debuffCount >= 16 then
+    return c.buffStacksById[spellId]
+  end
+  return nil
+end
+
+function DoiteTrack.GetVisibleAuraCounts()
+  local c = _EnsureTargetAuraCacheFresh()
+  if not c then
+    return 0, 0
+  end
+  return c.buffCount or 0, c.debuffCount or 0
+end
+
+function DoiteTrack.GetTrackedHiddenBuffCount()
+  return 0
+end
+
+function DoiteTrack.GetAuraCountSummary()
+  local buffs, debuffs = DoiteTrack.GetVisibleAuraCounts()
+  return buffs, debuffs, 0, (buffs + debuffs)
+end
+
+function DoiteTrack.ToggleDebugBuffCap()
+  DoiteTrack.debugBuffCap = not (DoiteTrack.debugBuffCap == true)
+  local state = DoiteTrack.debugBuffCap and "enabled" or "disabled"
+  print("DoiteTargetAuras: Debug buff cap " .. state)
+end
 ---------------------------------------------------------------
 -- Ingame usage
 ---------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Centralize and cache target buff/debuff presence and stacks into a dedicated API rather than relying on ad-hoc `auraSnapshot` reads. 
- Separate target-aura presence/stack helpers from the remaining-time tracking logic by renaming the module to make responsibilities clearer. 
- Make debuff-overflow handling and target stack queries more robust and reusable from condition checks.

### Description
- Renamed `Modules/DoiteTrack.lua` to `Modules/DoiteTargetAuras.lua`, exposed the module as `DoiteTargetAuras` and kept `DoiteTrack` as an alias pointing to the same table. 
- Added a cached per-frame target aura cache and helpers (`_EnsureTargetAuraCacheFresh`, `_WipeBoolTable`) and implemented the public API functions `HasBuff`, `HasBuffSpellId`, `HasDebuff`, `HasDebuffSpellId`, `GetBuffStacks`, `GetBuffStacksBySpellId`, `GetDebuffStacks`, `GetDebuffStacksBySpellId`, `GetVisibleAuraCounts`, and `GetAuraCountSummary`. 
- Updated `Modules/DoiteConditions.lua` to use the new `DoiteTargetAuras`/`DoiteTrack` API for target presence, overflow debuff detection, and stack lookups (replacing direct `auraSnapshot` access and inlined target logic). 
- Updated the addon table of contents `DoiteAuras.toc` to reference `Modules\DoiteTargetAuras.lua` instead of `Modules\DoiteTrack.lua`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d616b3aaa4832aa0b42d1218a3a7de)