### PR TITLE
Bump Nampower to 4.2.0, remove UnitXP distance fallbacks, and simplify target-distance UI/logic

### DIFF
--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -158,7 +158,7 @@ end
 -- Nampower requirement helper
 -- Requires a specific Nampower version
 ---------------------------------------------------------------
-local _NP_REQ_MAJOR, _NP_REQ_MINOR, _NP_REQ_PATCH = 4, 2, 0 -- Change when needed
+local _NP_REQ_MAJOR, _NP_REQ_MINOR, _NP_REQ_PATCH = 4, 1, 3 -- Change when needed
 
 local function _NP_GetVersion()
   if type(GetNampowerVersion) == "function" then
@@ -200,7 +200,7 @@ local function DA_GetMissingRequiredMods()
   -- Nampower: must be >= the version in _NP_REQ_MAJOR/_NP_REQ_MINOR/_NP_REQ_PATCH
   local npOK, npVerStr = _NP_AtLeast(_NP_REQ_MAJOR, _NP_REQ_MINOR, _NP_REQ_PATCH)
   if not npOK then
-    table.insert(missing, "Nampower 4.2.0+ (you have " .. tostring(npVerStr) .. ")")
+    table.insert(missing, "Nampower 4.1.3+ (you have " .. tostring(npVerStr) .. ")")
   end
 
   return missing
@@ -4195,7 +4195,7 @@ _daLoad:SetScript("OnEvent", function()
       else
         -- One or more missing → modern client requirement message
         local list = table.concat(missing, ", ")
-        cf:AddMessage("|cff6FA8DCDoiteAuras:|r This addon requires Nampower 4.2.0+. Missing: " .. list .. ".")
+        cf:AddMessage("|cff6FA8DCDoiteAuras:|r This addon requires Nampower 4.1.3+. Missing: " .. list .. ".")
         -- BLOCKER: after printing the message, hard-disable the addon
         _G["DoiteAuras_HardDisabled"] = true
 

--- a/DoiteAuras.lua
+++ b/DoiteAuras.lua
@@ -155,10 +155,10 @@ do
 end
 
 ---------------------------------------------------------------
--- Nampower / UnitXP SP3 requirement helper
--- Requires UnitXP & a specific Nampower version
+-- Nampower requirement helper
+-- Requires a specific Nampower version
 ---------------------------------------------------------------
-local _NP_REQ_MAJOR, _NP_REQ_MINOR, _NP_REQ_PATCH = 2, 40, 0 -- Change when needed
+local _NP_REQ_MAJOR, _NP_REQ_MINOR, _NP_REQ_PATCH = 4, 2, 0 -- Change when needed
 
 local function _NP_GetVersion()
   if type(GetNampowerVersion) == "function" then
@@ -200,19 +200,7 @@ local function DA_GetMissingRequiredMods()
   -- Nampower: must be >= the version in _NP_REQ_MAJOR/_NP_REQ_MINOR/_NP_REQ_PATCH
   local npOK, npVerStr = _NP_AtLeast(_NP_REQ_MAJOR, _NP_REQ_MINOR, _NP_REQ_PATCH)
   if not npOK then
-    table.insert(missing, "Nampower 2.40.0+ (you have " .. tostring(npVerStr) .. ")")
-  end
-
-  -- UnitXP SP3: pcall(UnitXP, "nop", "nop") must succeed
-  local hasUnitXP = false
-  if type(UnitXP) == "function" then
-    local ok = pcall(UnitXP, "nop", "nop")
-    if ok then
-      hasUnitXP = true
-    end
-  end
-  if not hasUnitXP then
-    table.insert(missing, "UnitXP SP3")
+    table.insert(missing, "Nampower 4.2.0+ (you have " .. tostring(npVerStr) .. ")")
   end
 
   return missing
@@ -4207,7 +4195,7 @@ _daLoad:SetScript("OnEvent", function()
       else
         -- One or more missing → modern client requirement message
         local list = table.concat(missing, ", ")
-        cf:AddMessage("|cff6FA8DCDoiteAuras:|r This addon requires Nampower 2.40.0+ and UnitXP SP3. Missing: " .. list .. ".")
+        cf:AddMessage("|cff6FA8DCDoiteAuras:|r This addon requires Nampower 4.2.0+. Missing: " .. list .. ".")
         -- BLOCKER: after printing the message, hard-disable the addon
         _G["DoiteAuras_HardDisabled"] = true
 

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -3348,82 +3348,15 @@ local function _NormalizeTargetField(val)
   if not val or val == "" or val == "Any" then
     return nil
   end
+  if val == "Melee range" then
+    return "In range"
+  end
   return val
 end
 
--- Optional: spell range in yards from DBC ("rangeMax" is yards * 10)
-local function _GetSpellMaxRangeYds(spellName)
-  if not spellName or not GetSpellIdForName or not GetSpellRecField then
-    return nil
-  end
-  local sid = GetSpellIdForName(spellName)
-  if not sid or sid <= 0 then
-    return nil
-  end
-
-  local raw = GetSpellRecField(sid, "rangeMax")
-  if not raw or raw <= 0 then
-    return nil
-  end
-
-  return raw / 10
-end
-
 ---------------------------------------------------------------
--- Spell range overrides and resurrection spell list
+-- Resurrection spell list
 ---------------------------------------------------------------
-
--- Spells whose IsSpellInRange return values are unreliable; treat them as explicit melee or ranged for distance checks instead of trusting API.
-local _SpellRangeOverrideByClass = {
-  WARRIOR = {
-    ["Heroic Strike"] = "melee",
-    ["Cleave"] = "melee",
-    -- Add more warrior spells here if needed.
-  },
-  -- Add other classes here if I discover more broken spells.
-}
-
-local _SpellRangeOverrideCache = {}
-local _playerClass = nil
-
-local function _GetPlayerClassToken()
-  if _playerClass and _playerClass ~= "" then
-    return _playerClass
-  end
-  if UnitClass then
-    local _, cls = UnitClass("player")
-    _playerClass = cls and string.upper(cls) or ""
-  else
-    _playerClass = ""
-  end
-  return _playerClass
-end
-
-local function _GetSpellRangeOverrideMode(spellName)
-  if not spellName then
-    return nil
-  end
-
-  local cached = _SpellRangeOverrideCache[spellName]
-  if cached ~= nil then
-    return (cached ~= false) and cached or nil
-  end
-
-  local cls = _GetPlayerClassToken()
-  local mode = nil
-  local byClass = _SpellRangeOverrideByClass[cls]
-  if byClass then
-    mode = byClass[spellName]
-  end
-
-  if mode then
-    _SpellRangeOverrideCache[spellName] = mode
-    return mode
-  end
-
-  _SpellRangeOverrideCache[spellName] = false
-  return nil
-end
 
 -- Resurrection spells that are allowed to do distance checks on dead friendly targets.
 local _ResurrectionSpellByName = {
@@ -3438,89 +3371,6 @@ local function _IsResurrectionSpell(spellName)
     return false
   end
   return _ResurrectionSpellByName[spellName] == true
-end
-
--- These are NOT yards, they are xp3's normalized melee meter.
-_G.DoiteConditions_MeleeRangeByRace = _G.DoiteConditions_MeleeRangeByRace or {
-  -- Small hitbox races
-  GNOME = 0.20,
-  GOBLIN = 0.20,
-
-  -- "Normal" body size races
-  HUMAN = 0.23,
-  ORC = 0.23,
-  TROLL = 0.23,
-  DWARF = 0.23,
-  NIGHTELF = 0.23,
-  BLOODELF = 0.23,
-  SCOURGE = 0.23,
-
-  -- Big bois
-  TAUREN = 0.30,
-}
-
-_G.DoiteConditions_MeleeRangeDefault = _G.DoiteConditions_MeleeRangeDefault or 0.23
-
-local _playerMeleeThreshold = nil
-
-local function _GetPlayerMeleeThreshold()
-  if _playerMeleeThreshold then
-    return _playerMeleeThreshold
-  end
-
-  local byRace = _G.DoiteConditions_MeleeRangeByRace or {}
-
-  local raceName, raceFile
-  if UnitRace then
-    raceName, raceFile = UnitRace("player")
-  end
-
-  local key = nil
-  if raceFile and raceFile ~= "" then
-    -- Stable, non-localized token: "Goblin","Tauren","NightElf","Scourge", etc.
-    key = string.upper(raceFile)
-  elseif raceName and raceName ~= "" then
-    -- Fallback: strip spaces and upper-case
-    key = string.upper(string.gsub(raceName, "%s+", ""))
-  end
-
-  local thr = _G.DoiteConditions_MeleeRangeDefault or 0.23
-  if key and byRace[key] then
-    thr = byRace[key]
-  end
-
-  _playerMeleeThreshold = thr
-  return thr
-end
-
-local function _RefreshPlayerMeleeThreshold()
-  _playerMeleeThreshold = nil
-  _GetPlayerMeleeThreshold()
-end
-
--- Generic distance in yards from player to unit; optional "mode" tuning for UnitXP
-local function _GetUnitDistanceYds(unit, mode)
-  if type(UnitXP) ~= "function" or not UnitExists then
-    return nil
-  end
-  local exists = UnitExists(unit)
-  if not exists then
-    return nil
-  end
-
-  local ok, dist
-  if mode == "melee" then
-    ok, dist = pcall(UnitXP, "distanceBetween", "player", unit, "meleeAutoAttack")
-  elseif mode == "aoe" then
-    ok, dist = pcall(UnitXP, "distanceBetween", "player", unit, "AoE")
-  else
-    ok, dist = pcall(UnitXP, "distanceBetween", "player", unit)
-  end
-
-  if not ok or type(dist) ~= "number" or dist < 0 then
-    return nil
-  end
-  return dist
 end
 
 -- Nampower-safe IsSpellInRange wrapper; returns true/false or nil if unknown
@@ -3551,12 +3401,6 @@ local function _IsSpellInRangeSafe(spellName, unit)
   end
   return nil
 end
-
--- Generic "In range" threshold (non-spell icons) in default UnitXP distance units.
-_G.DoiteConditions_GenericInRangeThreshold = _G.DoiteConditions_GenericInRangeThreshold or 1.5
-
--- Ranged-override threshold (yards) when treating a spell as pure ranged.
-_G.DoiteConditions_RangedOverrideThresholdYds = _G.DoiteConditions_RangedOverrideThresholdYds or 30
 
 -- Main "targetDistance" eval
 local function _PassesTargetDistance(condTbl, unit, spellName)
@@ -3627,7 +3471,7 @@ local function _PassesTargetDistance(condTbl, unit, spellName)
   end
 
   -- Dead-target guard for range-based checks
-  if val == "In range" or val == "Not in range" or val == "Melee range" then
+  if val == "In range" or val == "Not in range" then
     if isDead then
       local allowRes = false
       if spellName and isFriend and (not isHostile) then
@@ -3644,63 +3488,12 @@ local function _PassesTargetDistance(condTbl, unit, spellName)
   end
 
   ----------------------------------------------------------------
-  -- Range-based checks ("In range", "Not in range", "Melee range")
+  -- Range-based checks ("In range", "Not in range")
   ----------------------------------------------------------------
-  local inRange = nil
-  local overrideMode = nil
-
-  if spellName then
-    overrideMode = _GetSpellRangeOverrideMode(spellName)
-  end
-
-  -- Prefer IsSpellInRange when knowing which spell this icon represents
-  if spellName and overrideMode == nil then
-    inRange = _IsSpellInRangeSafe(spellName, unit)
-  end
-
-  -- Fallback when IsSpellInRange isn't usable
+  local inRange = _IsSpellInRangeSafe(spellName, unit)
   if inRange == nil then
-    if spellName then
-      if overrideMode == "melee" then
-        local dist = _GetUnitDistanceYds(unit, "melee") or _GetUnitDistanceYds(unit, nil)
-        if not dist then
-          inRange = true
-        else
-          local thr = _GetPlayerMeleeThreshold()
-          inRange = (dist <= thr)
-        end
-
-      elseif overrideMode == "range" then
-        -- Broken spell flagged as ranged: use a fixed yard threshold.
-        local dist = _GetUnitDistanceYds(unit, nil)
-        if not dist then
-          inRange = true
-        else
-          local thr = _G.DoiteConditions_RangedOverrideThresholdYds or 30
-          inRange = (dist <= thr)
-        end
-
-      else
-        -- No override: assume "melee-ish" ability when the addon can't do a proper range check
-        local dist = _GetUnitDistanceYds(unit, "melee") or _GetUnitDistanceYds(unit, nil)
-        if not dist then
-          -- No distance info at all: don't kill the icon.
-          inRange = true
-        else
-          local thr = _GetPlayerMeleeThreshold()
-          inRange = (dist <= thr)
-        end
-      end
-    else
-      -- Generic "In range" (e.g. items/auras) – tuneable threshold in xp3 units.
-      local dist = _GetUnitDistanceYds(unit, nil)
-      if not dist then
-        inRange = true
-      else
-        local generic = _G.DoiteConditions_GenericInRangeThreshold or 1.5
-        inRange = (dist <= generic)
-      end
-    end
+    -- Keep legacy behavior of not hiding an icon if range cannot be resolved.
+    inRange = true
   end
 
   if val == "In range" then
@@ -3708,18 +3501,8 @@ local function _PassesTargetDistance(condTbl, unit, spellName)
       return (posOK and inRange)
     end
     return inRange
-
   elseif val == "Not in range" then
-    return not inRange
-
-  elseif val == "Melee range" then
-    -- already blocked dead targets above; this is only for living units.
-    local dist = _GetUnitDistanceYds(unit, "melee") or _GetUnitDistanceYds(unit, nil)
-    if not dist then
-      return true
-    end
-    local thr = _GetPlayerMeleeThreshold()
-    return (dist <= thr)
+    return (not inRange)
   end
 
   return true
@@ -7934,7 +7717,7 @@ function DoiteConditions_OnUpdate(dt)
     end
   end
 
-  -- Lightweight distance heartbeat: keep "In range" / "Melee range" /
+  -- Lightweight distance heartbeat: keep target distance checks responsive.
   _distAccum = _distAccum + dt
   if _distAccum >= 0.15 then
     _distAccum = 0
@@ -8035,11 +7818,10 @@ eventFrame:SetScript("OnEvent", function()
     end
     dirty_ability, dirty_aura, dirty_target, dirty_power = true, true, true, true
 
-    -- Cache player class for lightweight warrior-specific logic + range overrides
+    -- Cache player class for lightweight warrior-specific logic
     local _, cls = UnitClass("player")
     cls = cls and string.upper(cls) or ""
     _isWarrior = (cls == "WARRIOR")
-    _playerClass = cls
 
     -- Prime time-heartbeat flags
     if _RebuildAbilityTimeHeartbeatFlag then
@@ -8054,10 +7836,6 @@ eventFrame:SetScript("OnEvent", function()
     if _RebuildTargetModsFlags then
       _RebuildTargetModsFlags()
     end
-    if _RefreshPlayerMeleeThreshold then
-      _RefreshPlayerMeleeThreshold()
-    end
-
   elseif event == "UNIT_AURA" then
     if arg1 == "player" then
       dirty_aura = true

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -3420,6 +3420,7 @@ local function _PassesTargetDistance(condTbl, unit, spellName)
   local isFriend = UnitIsFriend and UnitIsFriend("player", unit)
   local canAttack = UnitCanAttack and UnitCanAttack("player", unit)
   local isHostile = canAttack and (not isFriend)
+  local hasUnitXP = (type(UnitXP) == "function")
 
   -- Combined positional+range modes
   local wantPos = nil  -- "behind" / "front" / nil
@@ -3431,11 +3432,21 @@ local function _PassesTargetDistance(condTbl, unit, spellName)
     val = "In range"
   end
 
+  -- UnitXP unavailable fallback behavior for imported/saved configs:
+  -- - Behind / In front => treated as Any
+  -- - Behind & in range / In front & in range => treated as In range
+  if not hasUnitXP then
+    if val == "Behind" or val == "In front" then
+      return true
+    end
+    wantPos = nil
+  end
+
   -- Positional checks first (also supports the combined modes above)
   local posOK = true
 
   if val == "Behind" or wantPos == "behind" then
-    if type(UnitXP) == "function" then
+    if hasUnitXP then
       local ok, behind = pcall(UnitXP, "behind", "player", unit)
       if ok then
         posOK = (behind == true)
@@ -3451,7 +3462,7 @@ local function _PassesTargetDistance(condTbl, unit, spellName)
     end
 
   elseif val == "In front" or wantPos == "front" then
-    if type(UnitXP) == "function" then
+    if hasUnitXP then
       local okB, behind = pcall(UnitXP, "behind", "player", unit)
       local okS, inSight = pcall(UnitXP, "inSight", "player", unit)
       if not okB then

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -4417,7 +4417,21 @@ function UpdateItemStacksForMissing()
   ----------------------------------------------------------------
   -- Target Distance & Type dropdowns (shared lists)
   ----------------------------------------------------------------
-  local distanceChoices = { "Any", "In range", "Melee range", "Not in range", "Behind", "In front", "Behind & in range", "In front & in range" }
+  local distanceChoices = { "Any", "In range", "Not in range", "Behind", "In front", "Behind & in range", "In front & in range" }
+  local distanceNeedsUnitXP = {
+    ["Behind"] = true,
+    ["In front"] = true,
+    ["Behind & in range"] = true,
+    ["In front & in range"] = true
+  }
+
+  local function _HasUnitXP()
+    if type(UnitXP) ~= "function" then
+      return false
+    end
+    local ok = pcall(UnitXP, "nop", "nop")
+    return ok == true
+  end
 
   local unitTypeChoices = {
     "Any", "Players", "NPC", "Boss", "Not a boss",
@@ -4457,12 +4471,22 @@ function UpdateItemStacksForMissing()
     ClearDropdown(dd)
     UIDropDownMenu_Initialize(dd, function(frame, level, menuList)
       local info
+      local hasUnitXP = _HasUnitXP()
       for _, txt in ipairs(choices) do
         local picked = txt
         info = {}
-        info.text = txt
+        local requiresUnitXP = (field == "targetDistance") and (distanceNeedsUnitXP[picked] == true)
+        if requiresUnitXP and (not hasUnitXP) then
+          info.text = "|cff808080Req.UnitXP: " .. txt .. "|r"
+          info.disabled = true
+        else
+          info.text = txt
+        end
         info.value = txt
         info.func = function(button)
+          if requiresUnitXP and (not hasUnitXP) then
+            return
+          end
           local val = (button and button.value) or picked
           -- Update widget text/selection
           if UIDropDownMenu_SetSelectedValue then


### PR DESCRIPTION
### Motivation
- Remove reliance on the legacy `UnitXP` distance API for range calculations while keeping `IsSpellInRange` as the authoritative source.  
- Update required Nampower version to reflect newer API/compatibility (`4.2.0`).  
- Simplify and harden target-distance behavior and the dropdown UI so unavailable `UnitXP` options are disabled rather than making `UnitXP` a hard requirement.

### Description
- Updated Nampower version requirement constants to `4.2.0` and changed the user-facing message to require `Nampower 4.2.0+` in `DoiteAuras.lua`.  
- Removed the old `UnitXP` existence check from the global missing-deps collector so `UnitXP` is no longer treated as a required mod in `DA_GetMissingRequiredMods`.  
- Eliminated multiple `UnitXP`-based distance helper functions, race-based melee thresholds, and spell-range override logic from `Modules/DoiteConditions.lua`, and simplified `_PassesTargetDistance` to rely on `_IsSpellInRangeSafe` with a safe fallback of keeping an icon visible when range cannot be resolved.  
- Normalized the `Melee range` target distance to `In range` (via `_NormalizeTargetField`) and removed explicit `Melee range` pathing from the evaluation logic.  
- In `Modules/DoiteEdit.lua` removed `Melee range` from the distance choices and added UI logic to mark/disable dropdown entries that require `UnitXP` (e.g. positional options like `Behind`/`In front`) by detecting `UnitXP` availability with a safe `pcall` check.  
- Removed some now-unused player-class/race caching and melee-threshold refresh code paths to reflect the simplified distance model.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd42be2d38832abeeea8dfa9cd0241)