### PR TITLE
Add hunter Lacerate proc-window detection

### DIFF
--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -34,8 +34,6 @@ local str_find = string.find
 local str_gsub = string.gsub
 local SpellUsableArgCache = {}
 local _SoundStateByKey = {}
-local _GetCanonicalSpellNameFromData
-local _TalentIsKnownByName
 
 local function _DoitePlayConfiguredSound(fileName)
   if not fileName or fileName == "" then
@@ -155,59 +153,6 @@ _G.DoiteConditions_SpellIndexCache = SpellIndexCache
 _G.DoiteConditions_SpellBookTypeCache = _G.DoiteConditions_SpellBookTypeCache or {}
 
 local _isWarrior = false
-local _isHunter = false
-local _hunterLacerateProcEnabled = false
-local _hunterLacerateProcNextRefresh = 0
-
-local function _IsTrackingUsableAbilityByName(spellName)
-  if not spellName or spellName == "" then
-    return false
-  end
-  if not DoiteAurasDB or not DoiteAurasDB.spells then
-    return false
-  end
-
-  local key, data
-  for key, data in pairs(DoiteAurasDB.spells) do
-    if type(data) == "table" and data.type == "Ability"
-        and data.conditions and data.conditions.ability
-        and data.conditions.ability.mode == "usable" then
-      local nm = _GetCanonicalSpellNameFromData(data)
-      if nm == spellName then
-        return true
-      end
-    end
-  end
-
-  return false
-end
-
-local function _RefreshHunterLacerateProcEligibility(force)
-  if not _isHunter then
-    _hunterLacerateProcEnabled = false
-    _hunterLacerateProcNextRefresh = 0
-    return false
-  end
-
-  local now = _Now()
-  if (not force) and _hunterLacerateProcNextRefresh > now then
-    return _hunterLacerateProcEnabled
-  end
-
-  -- Refresh at most every 2 seconds on combat-log events.
-  _hunterLacerateProcNextRefresh = now + 2
-
-  if not _ProcWindowDuration("Lacerate") then
-    _hunterLacerateProcEnabled = false
-    return false
-  end
-
-  local trackingLacerate = _IsTrackingUsableAbilityByName("Lacerate")
-  local knowsTalent = _TalentIsKnownByName("Lacerate")
-
-  _hunterLacerateProcEnabled = (trackingLacerate and knowsTalent) and true or false
-  return _hunterLacerateProcEnabled
-end
 
 local function _GetSpellIndexByName(spellName)
   if not spellName then
@@ -2289,7 +2234,7 @@ end
 -- Keep warrior-specific state for target-matching
 local _WarriorProc = { OP_until = 0, OP_target = nil, REV_until = 0 }
 -- Canonical ability name resolver (spellbook name preferred)
-_GetCanonicalSpellNameFromData = function(data)
+local function _GetCanonicalSpellNameFromData(data)
   if not data or type(data) ~= "table" then
     return nil
   end
@@ -2505,10 +2450,6 @@ do
     _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
     _daClassCL:SetScript("OnEvent", function()
-      if not _RefreshHunterLacerateProcEligibility(false) then
-        return
-      end
-
       local line = arg1
       if not line or line == "" then
         return
@@ -2963,7 +2904,7 @@ local function _TargetHasAuraBySpellId(spellId, wantDebuff)
 end
 
 -- Talent helpers for auraConditions (Known / Not known)
-_TalentIsKnownByName = function(talentName)
+local function _TalentIsKnownByName(talentName)
   if not talentName or talentName == "" then
     return false
   end
@@ -8033,8 +7974,6 @@ eventFrame:SetScript("OnEvent", function()
     local _, cls = UnitClass("player")
     cls = cls and string.upper(cls) or ""
     _isWarrior = (cls == "WARRIOR")
-    _isHunter = (cls == "HUNTER")
-    _RefreshHunterLacerateProcEligibility(true)
 
     -- Prime time-heartbeat flags
     if _RebuildAbilityTimeHeartbeatFlag then
@@ -8077,7 +8016,6 @@ eventFrame:SetScript("OnEvent", function()
         btCache[k] = nil
       end
     end
-    _RefreshHunterLacerateProcEligibility(true)
     dirty_ability = true
 
   elseif event == "PLAYER_TARGET_CHANGED" then

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2187,14 +2187,8 @@ _G.DoiteConditions_ProcWindowDurations = _G.DoiteConditions_ProcWindowDurations 
   ["Surprise Attack"] = 4.0,
   ["Riposte"] = 4.0,
   ["Arcane Surge"] = 4.0,
-  ["Lacerate"] = 3.0,
+  ["Lacerate"] = 4.0,
 }
-do
-  local tbl = _G.DoiteConditions_ProcWindowDurations
-  if tbl and (type(tbl["Lacerate"]) ~= "number" or tbl["Lacerate"] <= 0) then
-    tbl["Lacerate"] = 3.0
-  end
-end
 
 -- SpellName -> absolute endTime (GetTime() + duration)
 _G.DoiteConditions_ProcUntil = _G.DoiteConditions_ProcUntil or {}

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2189,6 +2189,12 @@ _G.DoiteConditions_ProcWindowDurations = _G.DoiteConditions_ProcWindowDurations 
   ["Arcane Surge"] = 4.0,
   ["Lacerate"] = 3.0,
 }
+do
+  local tbl = _G.DoiteConditions_ProcWindowDurations
+  if tbl and (type(tbl["Lacerate"]) ~= "number" or tbl["Lacerate"] <= 0) then
+    tbl["Lacerate"] = 3.0
+  end
+end
 
 -- SpellName -> absolute endTime (GetTime() + duration)
 _G.DoiteConditions_ProcUntil = _G.DoiteConditions_ProcUntil or {}

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2306,167 +2306,205 @@ end)
 local _daClassCL = CreateFrame("Frame", "DoiteClassCL")
 local _daClassCL2 = CreateFrame("Frame", "DoiteClassCL2")
 
+local function _IsTrackedProcAbility(spellName)
+  if not spellName or spellName == "" then
+    return false
+  end
+  local db = DoiteAurasDB and DoiteAurasDB.spells
+  if not db then
+    return false
+  end
+
+  local _, data
+  for _, data in pairs(db) do
+    if type(data) == "table" and data.type == "Ability"
+        and data.conditions and data.conditions.ability then
+      local c = data.conditions.ability
+      if c and (c.mode == "usable" or c.mode == "notcd") then
+        local nm = _GetCanonicalSpellNameFromData(data)
+        if nm == spellName then
+          return true
+        end
+      end
+    end
+  end
+
+  return false
+end
+
 do
   local _, cls = UnitClass("player")
   cls = cls and string.upper(cls) or ""
 
   if cls == "WARRIOR" then
-    -- Overpower: needs dodge detection
-    _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
-	_daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    if _IsTrackedProcAbility("Overpower") then
+      -- Overpower: needs dodge detection
+      _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
+      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-    _daClassCL:SetScript("OnEvent", function()
-      local line = arg1
-      if not line or line == "" then
-        return
-      end
+      _daClassCL:SetScript("OnEvent", function()
+        local line = arg1
+        if not line or line == "" then
+          return
+        end
 
-      -- Overpower: target dodged you
-      local tgt
-      local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
-      if t1 then
-        tgt = t1
-      else
-        local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
-        tgt = t2
-      end
+        -- Overpower: target dodged you
+        local tgt
+        local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
+        if t1 then
+          tgt = t1
+        else
+          local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
+          tgt = t2
+        end
 
-      if tgt then
-        tgt = str_gsub(tgt, "%s*[%.!%?]+%s*$", "")
-        _WarriorProc.OP_target = tgt
+        if tgt then
+          tgt = str_gsub(tgt, "%s*[%.!%?]+%s*$", "")
+          _WarriorProc.OP_target = tgt
 
-        local now = _Now()
-        local dur = _ProcWindowDuration("Overpower") or 4.0
-        _WarriorProc.OP_until = now + dur
-        _ProcWindowSet("Overpower", _WarriorProc.OP_until)
-      end
-    end)
+          local now = _Now()
+          local dur = _ProcWindowDuration("Overpower") or 4.0
+          _WarriorProc.OP_until = now + dur
+          _ProcWindowSet("Overpower", _WarriorProc.OP_until)
+        end
+      end)
+    end
 
-    -- Revenge: needs incoming hits/blocks/parries/dodges
-    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
-    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
+    if _IsTrackedProcAbility("Revenge") then
+      -- Revenge: needs incoming hits/blocks/parries/dodges
+      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
+      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
 
-    _daClassCL2:SetScript("OnEvent", function()
-      local line = arg1
-      if not line or line == "" then
-        return
-      end
+      _daClassCL2:SetScript("OnEvent", function()
+        local line = arg1
+        if not line or line == "" then
+          return
+        end
 
-      -- Revenge: you dodged/parried/blocked
-      if str_find(line, "You dodge")
-          or str_find(line, "You parry")
-          or str_find(line, "You block")
-          or ((str_find(line, " hits you for ") or str_find(line, " crits you for "))
-          and str_find(line, " blocked)")) then
+        -- Revenge: you dodged/parried/blocked
+        if str_find(line, "You dodge")
+            or str_find(line, "You parry")
+            or str_find(line, "You block")
+            or ((str_find(line, " hits you for ") or str_find(line, " crits you for "))
+            and str_find(line, " blocked)")) then
 
-        local now = _Now()
-        local dur = _ProcWindowDuration("Revenge") or 4.0
-        _WarriorProc.REV_until = now + dur
-        _ProcWindowSet("Revenge", _WarriorProc.REV_until)
+          local now = _Now()
+          local dur = _ProcWindowDuration("Revenge") or 4.0
+          _WarriorProc.REV_until = now + dur
+          _ProcWindowSet("Revenge", _WarriorProc.REV_until)
 
-        dirty_ability = true
-      end
-    end)
+          dirty_ability = true
+        end
+      end)
+    end
 
   elseif cls == "ROGUE" then
-    -- Surprise Attack: needs dodge detection
-    _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
-    _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    if _IsTrackedProcAbility("Surprise Attack") then
+      -- Surprise Attack: needs dodge detection
+      _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
+      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-    _daClassCL:SetScript("OnEvent", function()
-      local line = arg1
-      if not line or line == "" then
-        return
-      end
-
-      -- Surprise Attack: target dodged you
-      local dodged = false
-      local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
-      if t1 then
-        dodged = true
-      else
-        local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
-        if t2 then
-          dodged = true
+      _daClassCL:SetScript("OnEvent", function()
+        local line = arg1
+        if not line or line == "" then
+          return
         end
-      end
 
-      if dodged then
-        local dur = _ProcWindowDuration("Surprise Attack")
-        if dur then
+        -- Surprise Attack: target dodged you
+        local dodged = false
+        local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
+        if t1 then
+          dodged = true
+        else
+          local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
+          if t2 then
+            dodged = true
+          end
+        end
+
+        if dodged then
+          local dur = _ProcWindowDuration("Surprise Attack")
+          if dur then
+            local now = _Now()
+            _ProcWindowSet("Surprise Attack", now + dur)
+            dirty_ability = true
+          end
+        end
+      end)
+    end
+
+    if _IsTrackedProcAbility("Riposte") then
+      -- Riposte: procs on YOUR parry (not target-bound)
+      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
+      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
+
+      _daClassCL2:SetScript("OnEvent", function()
+        local line = arg1
+        if not line or line == "" then
+          return
+        end
+
+        -- Riposte: you parried an attack
+        if str_find(line, "You parry") then
+          local dur = _ProcWindowDuration("Riposte") or 4.0
           local now = _Now()
-          _ProcWindowSet("Surprise Attack", now + dur)
+          _ProcWindowSet("Riposte", now + dur)
           dirty_ability = true
         end
-      end
-    end)
-
-    -- Riposte: procs on YOUR parry (not target-bound)
-    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
-    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
-
-    _daClassCL2:SetScript("OnEvent", function()
-      local line = arg1
-      if not line or line == "" then
-        return
-      end
-
-      -- Riposte: you parried an attack
-      if str_find(line, "You parry") then
-        local dur = _ProcWindowDuration("Riposte") or 4.0
-        local now = _Now()
-        _ProcWindowSet("Riposte", now + dur)
-        dirty_ability = true
-      end
-    end)
+      end)
+    end
 
   elseif cls == "MAGE" then
-    -- Arcane Surge: needs resist detection
-    _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    if _IsTrackedProcAbility("Arcane Surge") then
+      -- Arcane Surge: needs resist detection
+      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-    _daClassCL:SetScript("OnEvent", function()
-      local line = arg1
-      if not line or line == "" then
-        return
-      end
-
-      -- Arcane Surge: spell was resisted (fully or partially)
-      if str_find(line, " was resisted")
-          or str_find(line, " resisted%)")
-          or str_find(line, " resisted by")
-          or str_find(line, " resists your ") then
-
-        local dur = _ProcWindowDuration("Arcane Surge")
-        if dur then
-          local now = _Now()
-          _ProcWindowSet("Arcane Surge", now + dur)
-          dirty_ability = true
+      _daClassCL:SetScript("OnEvent", function()
+        local line = arg1
+        if not line or line == "" then
+          return
         end
-      end
-    end)
+
+        -- Arcane Surge: spell was resisted (fully or partially)
+        if str_find(line, " was resisted")
+            or str_find(line, " resisted%)")
+            or str_find(line, " resisted by")
+            or str_find(line, " resists your ") then
+
+          local dur = _ProcWindowDuration("Arcane Surge")
+          if dur then
+            local now = _Now()
+            _ProcWindowSet("Arcane Surge", now + dur)
+            dirty_ability = true
+          end
+        end
+      end)
+    end
   elseif cls == "HUNTER" then
-    -- Lacerate: procs on any player crit, not target-bound.
-    _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_HITS")
-    _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    if _IsTrackedProcAbility("Lacerate") then
+      -- Lacerate: procs on any player crit, not target-bound.
+      _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_HITS")
+      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-    _daClassCL:SetScript("OnEvent", function()
-      local line = arg1
-      if not line or line == "" then
-        return
-      end
-
-      -- White crit: "You crit [target] for #."
-      -- Ability crit: "Your [ability] crits [target] for #."
-      if str_find(line, "^You%s+crit%s+.+%s+for%s+")
-          or str_find(line, "^Your%s+.+%s+crits%s+.+%s+for%s+") then
-        local dur = _ProcWindowDuration("Lacerate")
-        if dur then
-          local now = _Now()
-          _ProcWindowSet("Lacerate", now + dur)
-          dirty_ability = true
+      _daClassCL:SetScript("OnEvent", function()
+        local line = arg1
+        if not line or line == "" then
+          return
         end
-      end
-    end)
+
+        -- White crit: "You crit [target] for #."
+        -- Ability crit: "Your [ability] crits [target] for #."
+        if str_find(line, "^You%s+crit%s+.+%s+for%s+")
+            or str_find(line, "^Your%s+.+%s+crits%s+.+%s+for%s+") then
+          local dur = _ProcWindowDuration("Lacerate")
+          if dur then
+            local now = _Now()
+            _ProcWindowSet("Lacerate", now + dur)
+            dirty_ability = true
+          end
+        end
+      end)
+    end
   end
 end
 
@@ -6556,6 +6594,7 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
       local spellName = _GetCanonicalSpellNameFromData(dataTbl)
       local remCD, durCD = _AbilityCooldownByName(spellName)
       local remShown, durShown = nil, nil
+      local remIsProc = false
 
       -- 1) Normal cooldown remaining text (ONLY when user enabled it)
       if ca.textTimeRemaining == true then
@@ -6565,8 +6604,8 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
         end
       end
 
-      -- 2) Proc-window remaining text (ONLY for mode == "usable")
-      if (not remShown) and spellName and (ca.mode == "usable") then
+      -- 2) Proc-window remaining text (for mode == "usable" or "notcd")
+      if (not remShown) and spellName and (ca.mode == "usable" or ca.mode == "notcd") then
         local procDur = _ProcWindowDuration(spellName)
         if procDur then
           local realCd = false
@@ -6579,6 +6618,7 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
             if remProc and remProc > 0 then
               remShown = remProc
               durShown = procDur
+              remIsProc = true
             end
           end
         end
@@ -6588,6 +6628,9 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
         remText = _FmtRem(remShown)
         wantRem = (remText ~= nil)
         frame._daSortRem = remShown
+        frame._daRemIsProc = remIsProc and true or false
+      else
+        frame._daRemIsProc = false
       end
 
       ----------------------------------------------------------------
@@ -6713,7 +6756,15 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
     if remText ~= frame._daLastRemText then
       frame._daLastRemText = remText
       frame._daTextRem:SetText(remText)
-      frame._daTextRem:SetTextColor(1, 1, 1, 1)
+    end
+    local remIsProcNow = (frame._daRemIsProc == true)
+    if remIsProcNow ~= frame._daLastRemProcState then
+      frame._daLastRemProcState = remIsProcNow
+      if remIsProcNow then
+        frame._daTextRem:SetTextColor(0.2, 1, 0.2, 1)
+      else
+        frame._daTextRem:SetTextColor(1, 1, 1, 1)
+      end
     end
     frame._daTextRem:Show()
   end

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -34,6 +34,8 @@ local str_find = string.find
 local str_gsub = string.gsub
 local SpellUsableArgCache = {}
 local _SoundStateByKey = {}
+local _GetCanonicalSpellNameFromData
+local _TalentIsKnownByName
 
 local function _DoitePlayConfiguredSound(fileName)
   if not fileName or fileName == "" then
@@ -153,6 +155,59 @@ _G.DoiteConditions_SpellIndexCache = SpellIndexCache
 _G.DoiteConditions_SpellBookTypeCache = _G.DoiteConditions_SpellBookTypeCache or {}
 
 local _isWarrior = false
+local _isHunter = false
+local _hunterLacerateProcEnabled = false
+local _hunterLacerateProcNextRefresh = 0
+
+local function _IsTrackingUsableAbilityByName(spellName)
+  if not spellName or spellName == "" then
+    return false
+  end
+  if not DoiteAurasDB or not DoiteAurasDB.spells then
+    return false
+  end
+
+  local key, data
+  for key, data in pairs(DoiteAurasDB.spells) do
+    if type(data) == "table" and data.type == "Ability"
+        and data.conditions and data.conditions.ability
+        and data.conditions.ability.mode == "usable" then
+      local nm = _GetCanonicalSpellNameFromData(data)
+      if nm == spellName then
+        return true
+      end
+    end
+  end
+
+  return false
+end
+
+local function _RefreshHunterLacerateProcEligibility(force)
+  if not _isHunter then
+    _hunterLacerateProcEnabled = false
+    _hunterLacerateProcNextRefresh = 0
+    return false
+  end
+
+  local now = _Now()
+  if (not force) and _hunterLacerateProcNextRefresh > now then
+    return _hunterLacerateProcEnabled
+  end
+
+  -- Refresh at most every 2 seconds on combat-log events.
+  _hunterLacerateProcNextRefresh = now + 2
+
+  if not _ProcWindowDuration("Lacerate") then
+    _hunterLacerateProcEnabled = false
+    return false
+  end
+
+  local trackingLacerate = _IsTrackingUsableAbilityByName("Lacerate")
+  local knowsTalent = _TalentIsKnownByName("Lacerate")
+
+  _hunterLacerateProcEnabled = (trackingLacerate and knowsTalent) and true or false
+  return _hunterLacerateProcEnabled
+end
 
 local function _GetSpellIndexByName(spellName)
   if not spellName then
@@ -2187,6 +2242,7 @@ _G.DoiteConditions_ProcWindowDurations = _G.DoiteConditions_ProcWindowDurations 
   ["Surprise Attack"] = 4.0,
   ["Riposte"] = 4.0,
   ["Arcane Surge"] = 4.0,
+  ["Lacerate"] = 3.0,
 }
 
 -- SpellName -> absolute endTime (GetTime() + duration)
@@ -2233,7 +2289,7 @@ end
 -- Keep warrior-specific state for target-matching
 local _WarriorProc = { OP_until = 0, OP_target = nil, REV_until = 0 }
 -- Canonical ability name resolver (spellbook name preferred)
-local function _GetCanonicalSpellNameFromData(data)
+_GetCanonicalSpellNameFromData = function(data)
   if not data or type(data) ~= "table" then
     return nil
   end
@@ -2439,6 +2495,33 @@ do
         if dur then
           local now = _Now()
           _ProcWindowSet("Arcane Surge", now + dur)
+          dirty_ability = true
+        end
+      end
+    end)
+  elseif cls == "HUNTER" then
+    -- Lacerate: procs on any player crit, not target-bound.
+    _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_HITS")
+    _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+
+    _daClassCL:SetScript("OnEvent", function()
+      if not _RefreshHunterLacerateProcEligibility(false) then
+        return
+      end
+
+      local line = arg1
+      if not line or line == "" then
+        return
+      end
+
+      -- White crit: "You crit [target] for #."
+      -- Ability crit: "Your [ability] crits [target] for #."
+      if str_find(line, "^You%s+crit%s+.+%s+for%s+")
+          or str_find(line, "^Your%s+.+%s+crits%s+.+%s+for%s+") then
+        local dur = _ProcWindowDuration("Lacerate")
+        if dur then
+          local now = _Now()
+          _ProcWindowSet("Lacerate", now + dur)
           dirty_ability = true
         end
       end
@@ -2880,7 +2963,7 @@ local function _TargetHasAuraBySpellId(spellId, wantDebuff)
 end
 
 -- Talent helpers for auraConditions (Known / Not known)
-local function _TalentIsKnownByName(talentName)
+_TalentIsKnownByName = function(talentName)
   if not talentName or talentName == "" then
     return false
   end
@@ -7950,6 +8033,8 @@ eventFrame:SetScript("OnEvent", function()
     local _, cls = UnitClass("player")
     cls = cls and string.upper(cls) or ""
     _isWarrior = (cls == "WARRIOR")
+    _isHunter = (cls == "HUNTER")
+    _RefreshHunterLacerateProcEligibility(true)
 
     -- Prime time-heartbeat flags
     if _RebuildAbilityTimeHeartbeatFlag then
@@ -7992,6 +8077,7 @@ eventFrame:SetScript("OnEvent", function()
         btCache[k] = nil
       end
     end
+    _RefreshHunterLacerateProcEligibility(true)
     dirty_ability = true
 
   elseif event == "PLAYER_TARGET_CHANGED" then

--- a/Modules/DoiteConditions.lua
+++ b/Modules/DoiteConditions.lua
@@ -2306,7 +2306,7 @@ end)
 local _daClassCL = CreateFrame("Frame", "DoiteClassCL")
 local _daClassCL2 = CreateFrame("Frame", "DoiteClassCL2")
 
-local function _IsTrackedProcAbility(spellName)
+local function _HasTrackedProcSpell(spellName)
   if not spellName or spellName == "" then
     return false
   end
@@ -2317,14 +2317,10 @@ local function _IsTrackedProcAbility(spellName)
 
   local _, data
   for _, data in pairs(db) do
-    if type(data) == "table" and data.type == "Ability"
-        and data.conditions and data.conditions.ability then
-      local c = data.conditions.ability
-      if c and (c.mode == "usable" or c.mode == "notcd") then
-        local nm = _GetCanonicalSpellNameFromData(data)
-        if nm == spellName then
-          return true
-        end
+    if type(data) == "table" and data.type == "Ability" then
+      local nm = data.name or data.displayName
+      if nm == spellName then
+        return true
       end
     end
   end
@@ -2337,174 +2333,186 @@ do
   cls = cls and string.upper(cls) or ""
 
   if cls == "WARRIOR" then
-    if _IsTrackedProcAbility("Overpower") then
-      -- Overpower: needs dodge detection
-      _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
-      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    -- Overpower: needs dodge detection
+    _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
+	_daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-      _daClassCL:SetScript("OnEvent", function()
-        local line = arg1
-        if not line or line == "" then
-          return
-        end
+    _daClassCL:SetScript("OnEvent", function()
+      if not _HasTrackedProcSpell("Overpower") then
+        return
+      end
 
-        -- Overpower: target dodged you
-        local tgt
-        local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
-        if t1 then
-          tgt = t1
-        else
-          local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
-          tgt = t2
-        end
+      local line = arg1
+      if not line or line == "" then
+        return
+      end
 
-        if tgt then
-          tgt = str_gsub(tgt, "%s*[%.!%?]+%s*$", "")
-          _WarriorProc.OP_target = tgt
+      -- Overpower: target dodged you
+      local tgt
+      local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
+      if t1 then
+        tgt = t1
+      else
+        local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
+        tgt = t2
+      end
 
-          local now = _Now()
-          local dur = _ProcWindowDuration("Overpower") or 4.0
-          _WarriorProc.OP_until = now + dur
-          _ProcWindowSet("Overpower", _WarriorProc.OP_until)
-        end
-      end)
-    end
+      if tgt then
+        tgt = str_gsub(tgt, "%s*[%.!%?]+%s*$", "")
+        _WarriorProc.OP_target = tgt
 
-    if _IsTrackedProcAbility("Revenge") then
-      -- Revenge: needs incoming hits/blocks/parries/dodges
-      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
-      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
+        local now = _Now()
+        local dur = _ProcWindowDuration("Overpower") or 4.0
+        _WarriorProc.OP_until = now + dur
+        _ProcWindowSet("Overpower", _WarriorProc.OP_until)
+      end
+    end)
 
-      _daClassCL2:SetScript("OnEvent", function()
-        local line = arg1
-        if not line or line == "" then
-          return
-        end
+    -- Revenge: needs incoming hits/blocks/parries/dodges
+    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
+    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
 
-        -- Revenge: you dodged/parried/blocked
-        if str_find(line, "You dodge")
-            or str_find(line, "You parry")
-            or str_find(line, "You block")
-            or ((str_find(line, " hits you for ") or str_find(line, " crits you for "))
-            and str_find(line, " blocked)")) then
+    _daClassCL2:SetScript("OnEvent", function()
+      if not _HasTrackedProcSpell("Revenge") then
+        return
+      end
 
-          local now = _Now()
-          local dur = _ProcWindowDuration("Revenge") or 4.0
-          _WarriorProc.REV_until = now + dur
-          _ProcWindowSet("Revenge", _WarriorProc.REV_until)
+      local line = arg1
+      if not line or line == "" then
+        return
+      end
 
-          dirty_ability = true
-        end
-      end)
-    end
+      -- Revenge: you dodged/parried/blocked
+      if str_find(line, "You dodge")
+          or str_find(line, "You parry")
+          or str_find(line, "You block")
+          or ((str_find(line, " hits you for ") or str_find(line, " crits you for "))
+          and str_find(line, " blocked)")) then
+
+        local now = _Now()
+        local dur = _ProcWindowDuration("Revenge") or 4.0
+        _WarriorProc.REV_until = now + dur
+        _ProcWindowSet("Revenge", _WarriorProc.REV_until)
+
+        dirty_ability = true
+      end
+    end)
 
   elseif cls == "ROGUE" then
-    if _IsTrackedProcAbility("Surprise Attack") then
-      -- Surprise Attack: needs dodge detection
-      _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
-      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    -- Surprise Attack: needs dodge detection
+    _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_MISSES")
+    _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-      _daClassCL:SetScript("OnEvent", function()
-        local line = arg1
-        if not line or line == "" then
-          return
-        end
+    _daClassCL:SetScript("OnEvent", function()
+      if not _HasTrackedProcSpell("Surprise Attack") then
+        return
+      end
 
-        -- Surprise Attack: target dodged you
-        local dodged = false
-        local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
-        if t1 then
+      local line = arg1
+      if not line or line == "" then
+        return
+      end
+
+      -- Surprise Attack: target dodged you
+      local dodged = false
+      local _, _, t1 = str_find(line, "You attack%.%s+(.+)%s+dodges")
+      if t1 then
+        dodged = true
+      else
+        local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
+        if t2 then
           dodged = true
-        else
-          local _, _, t2 = str_find(line, "Your%s+.+%s+was%s+dodged%s+by%s+(.+)")
-          if t2 then
-            dodged = true
-          end
         end
+      end
 
-        if dodged then
-          local dur = _ProcWindowDuration("Surprise Attack")
-          if dur then
-            local now = _Now()
-            _ProcWindowSet("Surprise Attack", now + dur)
-            dirty_ability = true
-          end
-        end
-      end)
-    end
-
-    if _IsTrackedProcAbility("Riposte") then
-      -- Riposte: procs on YOUR parry (not target-bound)
-      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
-      _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
-
-      _daClassCL2:SetScript("OnEvent", function()
-        local line = arg1
-        if not line or line == "" then
-          return
-        end
-
-        -- Riposte: you parried an attack
-        if str_find(line, "You parry") then
-          local dur = _ProcWindowDuration("Riposte") or 4.0
+      if dodged then
+        local dur = _ProcWindowDuration("Surprise Attack")
+        if dur then
           local now = _Now()
-          _ProcWindowSet("Riposte", now + dur)
+          _ProcWindowSet("Surprise Attack", now + dur)
           dirty_ability = true
         end
-      end)
-    end
+      end
+    end)
+
+    -- Riposte: procs on YOUR parry (not target-bound)
+    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
+    _daClassCL2:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS")
+
+    _daClassCL2:SetScript("OnEvent", function()
+      if not _HasTrackedProcSpell("Riposte") then
+        return
+      end
+
+      local line = arg1
+      if not line or line == "" then
+        return
+      end
+
+      -- Riposte: you parried an attack
+      if str_find(line, "You parry") then
+        local dur = _ProcWindowDuration("Riposte") or 4.0
+        local now = _Now()
+        _ProcWindowSet("Riposte", now + dur)
+        dirty_ability = true
+      end
+    end)
 
   elseif cls == "MAGE" then
-    if _IsTrackedProcAbility("Arcane Surge") then
-      -- Arcane Surge: needs resist detection
-      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    -- Arcane Surge: needs resist detection
+    _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-      _daClassCL:SetScript("OnEvent", function()
-        local line = arg1
-        if not line or line == "" then
-          return
+    _daClassCL:SetScript("OnEvent", function()
+      if not _HasTrackedProcSpell("Arcane Surge") then
+        return
+      end
+
+      local line = arg1
+      if not line or line == "" then
+        return
+      end
+
+      -- Arcane Surge: spell was resisted (fully or partially)
+      if str_find(line, " was resisted")
+          or str_find(line, " resisted%)")
+          or str_find(line, " resisted by")
+          or str_find(line, " resists your ") then
+
+        local dur = _ProcWindowDuration("Arcane Surge")
+        if dur then
+          local now = _Now()
+          _ProcWindowSet("Arcane Surge", now + dur)
+          dirty_ability = true
         end
-
-        -- Arcane Surge: spell was resisted (fully or partially)
-        if str_find(line, " was resisted")
-            or str_find(line, " resisted%)")
-            or str_find(line, " resisted by")
-            or str_find(line, " resists your ") then
-
-          local dur = _ProcWindowDuration("Arcane Surge")
-          if dur then
-            local now = _Now()
-            _ProcWindowSet("Arcane Surge", now + dur)
-            dirty_ability = true
-          end
-        end
-      end)
-    end
+      end
+    end)
   elseif cls == "HUNTER" then
-    if _IsTrackedProcAbility("Lacerate") then
-      -- Lacerate: procs on any player crit, not target-bound.
-      _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_HITS")
-      _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
+    -- Lacerate: procs on any player crit, not target-bound.
+    _daClassCL:RegisterEvent("CHAT_MSG_COMBAT_SELF_HITS")
+    _daClassCL:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 
-      _daClassCL:SetScript("OnEvent", function()
-        local line = arg1
-        if not line or line == "" then
-          return
-        end
+    _daClassCL:SetScript("OnEvent", function()
+      if not _HasTrackedProcSpell("Lacerate") then
+        return
+      end
 
-        -- White crit: "You crit [target] for #."
-        -- Ability crit: "Your [ability] crits [target] for #."
-        if str_find(line, "^You%s+crit%s+.+%s+for%s+")
-            or str_find(line, "^Your%s+.+%s+crits%s+.+%s+for%s+") then
-          local dur = _ProcWindowDuration("Lacerate")
-          if dur then
-            local now = _Now()
-            _ProcWindowSet("Lacerate", now + dur)
-            dirty_ability = true
-          end
+      local line = arg1
+      if not line or line == "" then
+        return
+      end
+
+      -- White crit: "You crit [target] for #."
+      -- Ability crit: "Your [ability] crits [target] for #."
+      if str_find(line, "^You%s+crit%s+.+%s+for%s+")
+          or str_find(line, "^Your%s+.+%s+crits%s+.+%s+for%s+") then
+        local dur = _ProcWindowDuration("Lacerate")
+        if dur then
+          local now = _Now()
+          _ProcWindowSet("Lacerate", now + dur)
+          dirty_ability = true
         end
-      end)
-    end
+      end
+    end)
   end
 end
 
@@ -6604,8 +6612,9 @@ local function _Doite_UpdateOverlayForFrame(frame, key, dataTbl, slideActive)
         end
       end
 
-      -- 2) Proc-window remaining text (for mode == "usable" or "notcd")
-      if (not remShown) and spellName and (ca.mode == "usable" or ca.mode == "notcd") then
+      -- 2) Proc-window remaining text (for usable/notcd/nocdoncd)
+      if (not remShown) and spellName
+          and (ca.mode == "usable" or ca.mode == "notcd" or ca.mode == "nocdoncd") then
         local procDur = _ProcWindowDuration(spellName)
         if procDur then
           local realCd = false

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -284,6 +284,9 @@ local function DoiteEdit_AbilitySupportsProcSound(data)
   end
   local tbl = _G.DoiteConditions_ProcWindowDurations
   local dur = tbl and tbl[spellName]
+  if (type(dur) ~= "number" or dur <= 0) and spellName == "Lacerate" then
+    dur = 3.0
+  end
   return (type(dur) == "number" and dur > 0) and true or false
 end
 

--- a/Modules/DoiteEdit.lua
+++ b/Modules/DoiteEdit.lua
@@ -284,9 +284,6 @@ local function DoiteEdit_AbilitySupportsProcSound(data)
   end
   local tbl = _G.DoiteConditions_ProcWindowDurations
   local dur = tbl and tbl[spellName]
-  if (type(dur) ~= "number" or dur <= 0) and spellName == "Lacerate" then
-    dur = 3.0
-  end
   return (type(dur) == "number" and dur > 0) and true or false
 end
 


### PR DESCRIPTION
### Motivation
- Add a hunter-specific proc similar to existing proc-window abilities (Surprise Attack, Overpower, Revenge, Arcane Surge, Riposte) for the Hunter talent "Lacerate" that should trigger on player crits and is not target-bound.

### Description
- Added `Lacerate` to the shared proc-window durations with a 3.0s default (`_G.DoiteConditions_ProcWindowDurations["Lacerate"] = 3.0`).
- Implemented a hunter-only combat-log listener for `CHAT_MSG_COMBAT_SELF_HITS` and `CHAT_MSG_SPELL_SELF_DAMAGE` that detects the crit lines (`You crit ... for ...` and `Your [ability] crits ... for ...`) and starts the `Lacerate` proc window via `_ProcWindowSet` when eligible.
- Added optimized eligibility gating so detection runs only when the player is a Hunter, the user is tracking a usable `Lacerate` ability icon, and the `Lacerate` talent is known, with a lightweight 2s refresh cache (`_RefreshHunterLacerateProcEligibility`).
- Added small helper utilities and forward declarations used by the new logic (`_IsTrackingUsableAbilityByName`, `_RefreshHunterLacerateProcEligibility`, forward-declared `_GetCanonicalSpellNameFromData` and `_TalentIsKnownByName` usage integration).

### Testing
- Verified the patch applied to `Modules/DoiteConditions.lua` and the new code appears in the diff (insertions for proc duration, hunter event handler, and helpers).
- Performed repository scans (`rg`, `sed`) to validate integration points and ensure handlers were registered in the correct class branch; these inspections succeeded.
- Attempted a Lua syntax check via `luac -p Modules/DoiteConditions.lua` but it could not be run in this environment because `luac` is not installed (syntax check not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e286a5a880832ab59f7c87dd03024c)